### PR TITLE
Lightwalletd API Documentation (additional comments in .proto source files)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ server.log
 coverage.out
 test-log
 lwd-api.html
+*.orig

--- a/docs/rtd/index.html
+++ b/docs/rtd/index.html
@@ -299,21 +299,21 @@
                   <td>hash</td>
                   <td><a href="#bytes">bytes</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>the ID (hash) of this block, same as in block explorers </p></td>
                 </tr>
               
                 <tr>
                   <td>prevHash</td>
                   <td><a href="#bytes">bytes</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>the ID (hash) of this block&#39;s predecessor </p></td>
                 </tr>
               
                 <tr>
                   <td>time</td>
                   <td><a href="#uint32">uint32</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>Unix epoch time when the block was mined </p></td>
                 </tr>
               
                 <tr>
@@ -327,7 +327,7 @@
                   <td>vtx</td>
                   <td><a href="#cash.z.wallet.sdk.rpc.CompactTx">CompactTx</a></td>
                   <td>repeated</td>
-                  <td><p>compact transactions from this block </p></td>
+                  <td><p>zero or more compact transactions from this block </p></td>
                 </tr>
               
             </tbody>
@@ -338,7 +338,7 @@
         
       
         <h3 id="cash.z.wallet.sdk.rpc.CompactOutput">CompactOutput</h3>
-        <p></p>
+        <p>output is a Sapling Output Description as described in section 7.4 of the</p><p>Zcash protocol spec. Total size is 948.</p>
 
         
           <table class="field-table">
@@ -351,21 +351,21 @@
                   <td>cmu</td>
                   <td><a href="#bytes">bytes</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>note commitment u-coordinate </p></td>
                 </tr>
               
                 <tr>
                   <td>epk</td>
                   <td><a href="#bytes">bytes</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>ephemeral public key </p></td>
                 </tr>
               
                 <tr>
                   <td>ciphertext</td>
                   <td><a href="#bytes">bytes</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>ciphertext and zkproof </p></td>
                 </tr>
               
             </tbody>
@@ -376,7 +376,7 @@
         
       
         <h3 id="cash.z.wallet.sdk.rpc.CompactSpend">CompactSpend</h3>
-        <p></p>
+        <p>CompactSpend is a Sapling Spend Description as described in 7.3 of the Zcash</p><p>protocol specification.</p>
 
         
           <table class="field-table">
@@ -389,7 +389,7 @@
                   <td>nf</td>
                   <td><a href="#bytes">bytes</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>nullifier (see the Zcash protocol specification) </p></td>
                 </tr>
               
             </tbody>
@@ -400,7 +400,7 @@
         
       
         <h3 id="cash.z.wallet.sdk.rpc.CompactTx">CompactTx</h3>
-        <p>Index and hash will allow the receiver to call out to chain</p><p>explorers or other data structures to retrieve more information</p><p>about this transaction.</p>
+        <p>CompactTx contains the minimum information for a wallet to know if this transaction</p><p>is relevant to it (either pays to it or spends from it) via shielded elements</p><p>only. This message will not encode a transparent-to-transparent transaction.</p>
 
         
           <table class="field-table">
@@ -413,14 +413,14 @@
                   <td>index</td>
                   <td><a href="#uint64">uint64</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>the index within the full block </p></td>
                 </tr>
               
                 <tr>
                   <td>hash</td>
                   <td><a href="#bytes">bytes</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>the ID (hash) of this transaction, same as in block explorers </p></td>
                 </tr>
               
                 <tr>
@@ -438,14 +438,14 @@ in a pure-Sapling context, the fee will be calculable as:
                   <td>spends</td>
                   <td><a href="#cash.z.wallet.sdk.rpc.CompactSpend">CompactSpend</a></td>
                   <td>repeated</td>
-                  <td><p> </p></td>
+                  <td><p>inputs </p></td>
                 </tr>
               
                 <tr>
                   <td>outputs</td>
                   <td><a href="#cash.z.wallet.sdk.rpc.CompactOutput">CompactOutput</a></td>
                   <td>repeated</td>
-                  <td><p> </p></td>
+                  <td><p>outputs </p></td>
                 </tr>
               
             </tbody>
@@ -597,35 +597,35 @@ in a pure-Sapling context, the fee will be calculable as:
                   <td>taddrSupport</td>
                   <td><a href="#bool">bool</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>true </p></td>
                 </tr>
               
                 <tr>
                   <td>chainName</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>either &#34;main&#34; or &#34;test&#34; </p></td>
                 </tr>
               
                 <tr>
                   <td>saplingActivationHeight</td>
                   <td><a href="#uint64">uint64</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>depends on mainnet or testnet </p></td>
                 </tr>
               
                 <tr>
                   <td>consensusBranchId</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>protocol identifier, see consensus/upgrades.cpp </p></td>
                 </tr>
               
                 <tr>
                   <td>blockHeight</td>
                   <td><a href="#uint64">uint64</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>latest block on the best chain </p></td>
                 </tr>
               
             </tbody>
@@ -636,7 +636,7 @@ in a pure-Sapling context, the fee will be calculable as:
         
       
         <h3 id="cash.z.wallet.sdk.rpc.PingResponse">PingResponse</h3>
-        <p>PingResponse is used to indicate concurrency, how many Ping rpcs</p><p>are executing upon entry and upon exit (after the delay).</p>
+        <p>PingResponse is used to indicate concurrency, how many Ping rpcs</p><p>are executing upon entry and upon exit (after the delay).</p><p>This rpc is used for testing only.</p>
 
         
           <table class="field-table">
@@ -667,7 +667,7 @@ in a pure-Sapling context, the fee will be calculable as:
         
       
         <h3 id="cash.z.wallet.sdk.rpc.RawTransaction">RawTransaction</h3>
-        <p>RawTransaction contains the complete transaction data. It also optionally includes </p><p>the block height in which the transaction was included</p>
+        <p>RawTransaction contains the complete transaction data. It also optionally includes </p><p>the block height in which the transaction was included.</p>
 
         
           <table class="field-table">
@@ -680,14 +680,14 @@ in a pure-Sapling context, the fee will be calculable as:
                   <td>data</td>
                   <td><a href="#bytes">bytes</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>exact data returned by zcash &#39;getrawtransaction&#39; </p></td>
                 </tr>
               
                 <tr>
                   <td>height</td>
                   <td><a href="#uint64">uint64</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>height that the transaction was mined (or -1) </p></td>
                 </tr>
               
             </tbody>
@@ -742,14 +742,14 @@ in a pure-Sapling context, the fee will be calculable as:
                   <td>address</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>t-address </p></td>
                 </tr>
               
                 <tr>
                   <td>range</td>
                   <td><a href="#cash.z.wallet.sdk.rpc.BlockRange">BlockRange</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>start, end heights </p></td>
                 </tr>
               
             </tbody>
@@ -773,21 +773,21 @@ in a pure-Sapling context, the fee will be calculable as:
                   <td>block</td>
                   <td><a href="#cash.z.wallet.sdk.rpc.BlockID">BlockID</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>block identifier, height or hash </p></td>
                 </tr>
               
                 <tr>
                   <td>index</td>
                   <td><a href="#uint64">uint64</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>index within the block </p></td>
                 </tr>
               
                 <tr>
                   <td>hash</td>
                   <td><a href="#bytes">bytes</a></td>
                   <td></td>
-                  <td><p> </p></td>
+                  <td><p>transaction ID (hash, txid) </p></td>
                 </tr>
               
             </tbody>
@@ -815,56 +815,56 @@ in a pure-Sapling context, the fee will be calculable as:
                 <td>GetLatestBlock</td>
                 <td><a href="#cash.z.wallet.sdk.rpc.ChainSpec">ChainSpec</a></td>
                 <td><a href="#cash.z.wallet.sdk.rpc.BlockID">BlockID</a></td>
-                <td><p>Compact Blocks</p></td>
+                <td><p>Return the height of the tip of the best chain</p></td>
               </tr>
             
               <tr>
                 <td>GetBlock</td>
                 <td><a href="#cash.z.wallet.sdk.rpc.BlockID">BlockID</a></td>
                 <td><a href="#cash.z.wallet.sdk.rpc.CompactBlock">CompactBlock</a></td>
-                <td><p></p></td>
+                <td><p>Return the compact block corresponding to the given block identifier</p></td>
               </tr>
             
               <tr>
                 <td>GetBlockRange</td>
                 <td><a href="#cash.z.wallet.sdk.rpc.BlockRange">BlockRange</a></td>
                 <td><a href="#cash.z.wallet.sdk.rpc.CompactBlock">CompactBlock</a> stream</td>
-                <td><p></p></td>
+                <td><p>Return a list of consecutive compact blocks</p></td>
               </tr>
             
               <tr>
                 <td>GetTransaction</td>
                 <td><a href="#cash.z.wallet.sdk.rpc.TxFilter">TxFilter</a></td>
                 <td><a href="#cash.z.wallet.sdk.rpc.RawTransaction">RawTransaction</a></td>
-                <td><p>Transactions</p></td>
+                <td><p>Return the requested full (not compact) transaction (as from zcashd)</p></td>
               </tr>
             
               <tr>
                 <td>SendTransaction</td>
                 <td><a href="#cash.z.wallet.sdk.rpc.RawTransaction">RawTransaction</a></td>
                 <td><a href="#cash.z.wallet.sdk.rpc.SendResponse">SendResponse</a></td>
-                <td><p></p></td>
+                <td><p>Submit the given transaction to the zcash network</p></td>
               </tr>
             
               <tr>
                 <td>GetAddressTxids</td>
                 <td><a href="#cash.z.wallet.sdk.rpc.TransparentAddressBlockFilter">TransparentAddressBlockFilter</a></td>
                 <td><a href="#cash.z.wallet.sdk.rpc.RawTransaction">RawTransaction</a> stream</td>
-                <td><p>t-Address support</p></td>
+                <td><p>Return the txids corresponding to the given t-address within the given block range</p></td>
               </tr>
             
               <tr>
                 <td>GetLightdInfo</td>
                 <td><a href="#cash.z.wallet.sdk.rpc.Empty">Empty</a></td>
                 <td><a href="#cash.z.wallet.sdk.rpc.LightdInfo">LightdInfo</a></td>
-                <td><p>Misc</p></td>
+                <td><p>Return information about this lightwalletd instance and the blockchain</p></td>
               </tr>
             
               <tr>
                 <td>Ping</td>
                 <td><a href="#cash.z.wallet.sdk.rpc.Duration">Duration</a></td>
                 <td><a href="#cash.z.wallet.sdk.rpc.PingResponse">PingResponse</a></td>
-                <td><p></p></td>
+                <td><p>Testing-only</p></td>
               </tr>
             
           </tbody>

--- a/walletrpc/compact_formats.pb.go
+++ b/walletrpc/compact_formats.pb.go
@@ -111,9 +111,9 @@ func (m *CompactBlock) GetVtx() []*CompactTx {
 	return nil
 }
 
-// Index and hash will allow the receiver to call out to chain
-// explorers or other data structures to retrieve more information
-// about this transaction.
+// CompactTx contains the minimum information for a wallet to know if this transaction
+// is relevant to it (either pays to it or spends from it) via shielded elements
+// only. This message will not encode a transparent-to-transparent transaction.
 type CompactTx struct {
 	Index uint64 `protobuf:"varint,1,opt,name=index,proto3" json:"index,omitempty"`
 	Hash  []byte `protobuf:"bytes,2,opt,name=hash,proto3" json:"hash,omitempty"`
@@ -190,6 +190,8 @@ func (m *CompactTx) GetOutputs() []*CompactOutput {
 	return nil
 }
 
+// CompactSpend is a Sapling Spend Description as described in 7.3 of the Zcash
+// protocol specification.
 type CompactSpend struct {
 	Nf                   []byte   `protobuf:"bytes,1,opt,name=nf,proto3" json:"nf,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -229,6 +231,8 @@ func (m *CompactSpend) GetNf() []byte {
 	return nil
 }
 
+// output is a Sapling Output Description as described in section 7.4 of the
+// Zcash protocol spec. Total size is 948.
 type CompactOutput struct {
 	Cmu                  []byte   `protobuf:"bytes,1,opt,name=cmu,proto3" json:"cmu,omitempty"`
 	Epk                  []byte   `protobuf:"bytes,2,opt,name=epk,proto3" json:"epk,omitempty"`

--- a/walletrpc/compact_formats.proto
+++ b/walletrpc/compact_formats.proto
@@ -14,21 +14,21 @@ option swift_prefix = "";
 //   2. Detect a spend of your shielded Sapling notes
 //   3. Update your witnesses to generate new Sapling spend proofs.
 message CompactBlock {
-    uint32 protoVersion = 1; // the version of this wire format, for storage
-    uint64 height = 2; // the height of this block
-    bytes hash = 3;
-    bytes prevHash = 4;
-    uint32 time = 5;
-    bytes header = 6; // (hash, prevHash, and time) OR (full header)
-    repeated CompactTx vtx = 7; // compact transactions from this block
+    uint32 protoVersion = 1;    // the version of this wire format, for storage
+    uint64 height = 2;          // the height of this block
+    bytes hash = 3;             // the ID (hash) of this block, same as in block explorers
+    bytes prevHash = 4;         // the ID (hash) of this block's predecessor
+    uint32 time = 5;            // Unix epoch time when the block was mined
+    bytes header = 6;           // (hash, prevHash, and time) OR (full header)
+    repeated CompactTx vtx = 7; // zero or more compact transactions from this block
 }
 
-// Index and hash will allow the receiver to call out to chain
-// explorers or other data structures to retrieve more information
-// about this transaction.
+// CompactTx contains the minimum information for a wallet to know if this transaction
+// is relevant to it (either pays to it or spends from it) via shielded elements
+// only. This message will not encode a transparent-to-transparent transaction.
 message CompactTx {
-    uint64 index = 1;
-    bytes hash = 2;
+    uint64 index = 1;   // the index within the full block
+    bytes hash = 2;     // the ID (hash) of this transaction, same as in block explorers
 
     // The transaction fee: present if server can provide. In the case of a
     // stateless server and a transaction with transparent inputs, this will be
@@ -37,16 +37,20 @@ message CompactTx {
     //    valueBalance + (sum(vPubNew) - sum(vPubOld) - sum(tOut))
     uint32 fee = 3;
 
-    repeated CompactSpend spends = 4;
-    repeated CompactOutput outputs = 5;
+    repeated CompactSpend spends = 4;   // inputs
+    repeated CompactOutput outputs = 5; // outputs
 }
 
+// CompactSpend is a Sapling Spend Description as described in 7.3 of the Zcash
+// protocol specification.
 message CompactSpend {
-    bytes nf = 1;
+    bytes nf = 1;   // nullifier (see the Zcash protocol specification)
 }
 
+// output is a Sapling Output Description as described in section 7.4 of the
+// Zcash protocol spec. Total size is 948.
 message CompactOutput {
-    bytes cmu = 1;
-    bytes epk = 2;
-    bytes ciphertext = 3;
+    bytes cmu = 1;          // note commitment u-coordinate
+    bytes epk = 2;          // ephemeral public key
+    bytes ciphertext = 3;   // ciphertext and zkproof
 }

--- a/walletrpc/service.pb.go
+++ b/walletrpc/service.pb.go
@@ -181,7 +181,7 @@ func (m *TxFilter) GetHash() []byte {
 }
 
 // RawTransaction contains the complete transaction data. It also optionally includes
-// the block height in which the transaction was included
+// the block height in which the transaction was included.
 type RawTransaction struct {
 	Data                 []byte   `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
 	Height               uint64   `protobuf:"varint,2,opt,name=height,proto3" json:"height,omitempty"`
@@ -525,6 +525,7 @@ func (m *Duration) GetIntervalUs() int64 {
 
 // PingResponse is used to indicate concurrency, how many Ping rpcs
 // are executing upon entry and upon exit (after the delay).
+// This rpc is used for testing only.
 type PingResponse struct {
 	Entry                int64    `protobuf:"varint,1,opt,name=entry,proto3" json:"entry,omitempty"`
 	Exit                 int64    `protobuf:"varint,2,opt,name=exit,proto3" json:"exit,omitempty"`
@@ -651,17 +652,21 @@ const _ = grpc.SupportPackageIsVersion6
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type CompactTxStreamerClient interface {
-	// Compact Blocks
+	// Return the height of the tip of the best chain
 	GetLatestBlock(ctx context.Context, in *ChainSpec, opts ...grpc.CallOption) (*BlockID, error)
+	// Return the compact block corresponding to the given block identifier
 	GetBlock(ctx context.Context, in *BlockID, opts ...grpc.CallOption) (*CompactBlock, error)
+	// Return a list of consecutive compact blocks
 	GetBlockRange(ctx context.Context, in *BlockRange, opts ...grpc.CallOption) (CompactTxStreamer_GetBlockRangeClient, error)
-	// Transactions
+	// Return the requested full (not compact) transaction (as from zcashd)
 	GetTransaction(ctx context.Context, in *TxFilter, opts ...grpc.CallOption) (*RawTransaction, error)
+	// Submit the given transaction to the zcash network
 	SendTransaction(ctx context.Context, in *RawTransaction, opts ...grpc.CallOption) (*SendResponse, error)
-	// t-Address support
+	// Return the txids corresponding to the given t-address within the given block range
 	GetAddressTxids(ctx context.Context, in *TransparentAddressBlockFilter, opts ...grpc.CallOption) (CompactTxStreamer_GetAddressTxidsClient, error)
-	// Misc
+	// Return information about this lightwalletd instance and the blockchain
 	GetLightdInfo(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*LightdInfo, error)
+	// Testing-only
 	Ping(ctx context.Context, in *Duration, opts ...grpc.CallOption) (*PingResponse, error)
 }
 
@@ -793,17 +798,21 @@ func (c *compactTxStreamerClient) Ping(ctx context.Context, in *Duration, opts .
 
 // CompactTxStreamerServer is the server API for CompactTxStreamer service.
 type CompactTxStreamerServer interface {
-	// Compact Blocks
+	// Return the height of the tip of the best chain
 	GetLatestBlock(context.Context, *ChainSpec) (*BlockID, error)
+	// Return the compact block corresponding to the given block identifier
 	GetBlock(context.Context, *BlockID) (*CompactBlock, error)
+	// Return a list of consecutive compact blocks
 	GetBlockRange(*BlockRange, CompactTxStreamer_GetBlockRangeServer) error
-	// Transactions
+	// Return the requested full (not compact) transaction (as from zcashd)
 	GetTransaction(context.Context, *TxFilter) (*RawTransaction, error)
+	// Submit the given transaction to the zcash network
 	SendTransaction(context.Context, *RawTransaction) (*SendResponse, error)
-	// t-Address support
+	// Return the txids corresponding to the given t-address within the given block range
 	GetAddressTxids(*TransparentAddressBlockFilter, CompactTxStreamer_GetAddressTxidsServer) error
-	// Misc
+	// Return information about this lightwalletd instance and the blockchain
 	GetLightdInfo(context.Context, *Empty) (*LightdInfo, error)
+	// Testing-only
 	Ping(context.Context, *Duration) (*PingResponse, error)
 }
 

--- a/walletrpc/service.proto
+++ b/walletrpc/service.proto
@@ -26,16 +26,16 @@ message BlockRange {
 // transaction: either a block and an index, or a direct transaction hash.
 // Currently, only specification by hash is supported.
 message TxFilter {
-     BlockID block = 1;
-     uint64 index = 2;
-     bytes hash = 3;
+     BlockID block = 1;     // block identifier, height or hash
+     uint64 index = 2;      // index within the block
+     bytes hash = 3;        // transaction ID (hash, txid)
 }
 
 // RawTransaction contains the complete transaction data. It also optionally includes 
-// the block height in which the transaction was included
+// the block height in which the transaction was included.
 message RawTransaction {
-    bytes data = 1;
-    uint64 height = 2;
+    bytes data = 1;     // exact data returned by zcash 'getrawtransaction'
+    uint64 height = 2;  // height that the transaction was mined (or -1)
 }
 
 // A SendResponse encodes an error code and a string. It is currently used
@@ -57,18 +57,18 @@ message Empty {}
 message LightdInfo {
     string version = 1;
     string vendor = 2;
-    bool   taddrSupport = 3;
-    string chainName = 4;
-    uint64 saplingActivationHeight = 5;
-    string consensusBranchId = 6;
-    uint64 blockHeight = 7;
+    bool   taddrSupport = 3;            // true
+    string chainName = 4;               // either "main" or "test"
+    uint64 saplingActivationHeight = 5; // depends on mainnet or testnet
+    string consensusBranchId = 6;       // protocol identifier, see consensus/upgrades.cpp
+    uint64 blockHeight = 7;             // latest block on the best chain
 }
 
 // TransparentAddressBlockFilter restricts the results to the given address
 // or block range.
 message TransparentAddressBlockFilter {
-    string address = 1;
-    BlockRange range = 2;
+    string address = 1;     // t-address
+    BlockRange range = 2;   // start, end heights
 }
 
 // Duration is currently used only for testing, so that the Ping rpc
@@ -80,25 +80,30 @@ message Duration {
 
 // PingResponse is used to indicate concurrency, how many Ping rpcs
 // are executing upon entry and upon exit (after the delay).
+// This rpc is used for testing only.
 message PingResponse {
     int64 entry = 1;
     int64 exit = 2;
 }
 
 service CompactTxStreamer {
-    // Compact Blocks
+    // Return the height of the tip of the best chain
     rpc GetLatestBlock(ChainSpec) returns (BlockID) {}
+    // Return the compact block corresponding to the given block identifier
     rpc GetBlock(BlockID) returns (CompactBlock) {}
+    // Return a list of consecutive compact blocks
     rpc GetBlockRange(BlockRange) returns (stream CompactBlock) {}
 
-    // Transactions
+    // Return the requested full (not compact) transaction (as from zcashd)
     rpc GetTransaction(TxFilter) returns (RawTransaction) {}
+    // Submit the given transaction to the zcash network
     rpc SendTransaction(RawTransaction) returns (SendResponse) {}
 
-    // t-Address support
+    // Return the txids corresponding to the given t-address within the given block range
     rpc GetAddressTxids(TransparentAddressBlockFilter) returns (stream RawTransaction) {}
 
-    // Misc
+    // Return information about this lightwalletd instance and the blockchain
     rpc GetLightdInfo(Empty) returns (LightdInfo) {}
+    // Testing-only
     rpc Ping(Duration) returns (PingResponse) {}
 }


### PR DESCRIPTION
Closes #131. The updated documentation is in `docs/rtd/index.html` (generated file but in source control).