### PR TITLE
corruption detection fix

### DIFF
--- a/common/cache.go
+++ b/common/cache.go
@@ -220,7 +220,7 @@ func NewBlockCache(dbPath string, chainName string, startHeight int, redownload 
 			break
 		}
 		length := binary.LittleEndian.Uint32(lengths[i*4 : (i+1)*4])
-		if length < 78 || length > 4*1000*1000 {
+		if length < 74 || length > 4*1000*1000 {
 			Log.Warning("lengths file has impossible value ", length)
 			c.recoverFromCorruption(c.nextBlock)
 			break


### PR DESCRIPTION
This PR reduces the minimum acceptable block size to 74 bytes. Details: Lightwalletd tries to detect corruption of its cache files each time it starts up, and one of the checks is that the length of each compact block (as recorded in the `lengths` file) isn't an unexpected value. The smallest possible block size was thought to be 78 bytes, but it's actually 74 bytes. So the `lengths` file was deemed corrupt if a 74-byte block exists. There are no 74-byte blocks in mainnet or the "real" testnet, but apparently there are other versions of testnet (see https://github.com/zcash/ZcashLightClientKit/issues/128#issuecomment-632411163) that do have 74-byte blocks. 