### PR TITLE
increase the 252 per-block transaction limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ test-log
 lwd-api.html
 *.orig
 __debug_bin
+.vscode

--- a/common/cache_test.go
+++ b/common/cache_test.go
@@ -46,9 +46,12 @@ func TestCache(t *testing.T) {
 	for _, test := range compactTests {
 		blockData, _ := hex.DecodeString(test.Full)
 		block := parser.NewBlock()
-		_, err = block.ParseFromSlice(blockData)
+		blockData, err = block.ParseFromSlice(blockData)
 		if err != nil {
 			t.Fatal(err)
+		}
+		if len(blockData) > 0 {
+			t.Error("Extra data remaining")
 		}
 		compacts = append(compacts, block.ToCompact())
 	}

--- a/docs/rtd/index.html
+++ b/docs/rtd/index.html
@@ -738,8 +738,8 @@ from the given URL. Blocks are one per line, hex-encoded (not JSON).</p></td>
                 <td><p>StageBlocksCreate is like the previous two, except it creates &#39;count&#39;
 empty blocks at consecutive heights starting at height &#39;height&#39;. The
 &#39;nonce&#39; is part of the header, so it contributes to the block hash; this
-lets you create two fake blocks with the same transactions (or no
-transactions) and same height, with two different hashes.</p></td>
+lets you create identical blocks (same transactions and height), but with
+different hashes.</p></td>
               </tr>
             
               <tr>
@@ -757,10 +757,9 @@ by the mock zcashd).</p></td>
                 <td>StageTransactions</td>
                 <td><a href="#cash.z.wallet.sdk.rpc.DarksideTransactionsURL">DarksideTransactionsURL</a></td>
                 <td><a href="#cash.z.wallet.sdk.rpc.Empty">Empty</a></td>
-                <td><p>StageTransactions is the same except the transactions are fetched
-from the given url. They are all staged into the block at the given
-height. Staging transactions at multiple different heights requires
-multiple calls.</p></td>
+                <td><p>StageTransactions is the same except the transactions are fetched from
+the given url. They are all staged into the block at the given height.
+Staging transactions to different heights requires multiple calls.</p></td>
               </tr>
             
               <tr>
@@ -770,12 +769,14 @@ multiple calls.</p></td>
                 <td><p>ApplyStaged iterates the list of blocks that were staged by the
 StageBlocks*() gRPCs, in the order they were staged, and &#34;merges&#34; each
 into the active, working blocks list that the mock zcashd is presenting
-to lightwalletd. The resulting working block list can&#39;t have gaps; if the
-working block range is 1000-1006, and the staged block range is 1003-1004,
-the resulting range is 1000-1004, with 1000-1002 unchanged, blocks
-1003-1004 from the new range, and 1005-1006 dropped. After merging all
-blocks, ApplyStaged() appends staged transactions (in the order received)
-into each one&#39;s corresponding block. The staging area is then cleared.
+to lightwalletd. Even as each block is applied, the active list can&#39;t
+have gaps; if the active block range is 1000-1006, and the staged block
+range is 1003-1004, the resulting range is 1000-1004, with 1000-1002
+unchanged, blocks 1003-1004 from the new range, and 1005-1006 dropped.
+
+After merging all blocks, ApplyStaged() appends staged transactions (in
+the order received) into each one&#39;s corresponding (by height) block
+The staging area is then cleared.
 
 The argument specifies the latest block height that mock zcashd reports
 (i.e. what&#39;s returned by GetLatestBlock). Note that ApplyStaged() can

--- a/parser/block.go
+++ b/parser/block.go
@@ -129,7 +129,8 @@ func (b *Block) ParseFromSlice(data []byte) (rest []byte, err error) {
 	data = []byte(s)
 
 	vtx := make([]*Transaction, 0, txCount)
-	for i := 0; len(data) > 0; i++ {
+	var i int
+	for i = 0; i < txCount && len(data) > 0; i++ {
 		tx := NewTransaction()
 		data, err = tx.ParseFromSlice(data)
 		if err != nil {
@@ -137,7 +138,9 @@ func (b *Block) ParseFromSlice(data []byte) (rest []byte, err error) {
 		}
 		vtx = append(vtx, tx)
 	}
-
+	if i < txCount {
+		return nil, errors.New("parsing block transactions: not enough data")
+	}
 	b.hdr = hdr
 	b.vtx = vtx
 

--- a/parser/block_header_test.go
+++ b/parser/block_header_test.go
@@ -249,7 +249,7 @@ func TestWriteCompactLengthPrefixedLen(t *testing.T) {
 func TestWriteCompactLengthPrefixed(t *testing.T) {
 	var b bytes.Buffer
 	val := []byte{22, 33, 44}
-	WriteCompactLengthPrefixed(&b, val)
+	writeCompactLengthPrefixed(&b, val)
 	r := make([]byte, 4)
 	b.Read(r)
 	expected := []byte{3, 22, 33, 44}

--- a/parser/block_test.go
+++ b/parser/block_test.go
@@ -50,6 +50,9 @@ func TestBlockParser(t *testing.T) {
 			t.Error(errors.Wrap(err, fmt.Sprintf("parsing block %d", i)))
 			continue
 		}
+		if len(blockData) > 0 {
+			t.Error("Extra data remaining")
+		}
 
 		// Some basic sanity checks
 		if block.hdr.Version != 4 {
@@ -142,6 +145,9 @@ func TestGenesisBlockParser(t *testing.T) {
 			t.Error(err)
 			continue
 		}
+		if len(blockData) > 0 {
+			t.Error("Extra data remaining")
+		}
 
 		// Some basic sanity checks
 		if block.hdr.Version != 4 {
@@ -182,6 +188,9 @@ func TestCompactBlocks(t *testing.T) {
 		if err != nil {
 			t.Error(errors.Wrap(err, fmt.Sprintf("parsing testnet block %d", test.BlockHeight)))
 			continue
+		}
+		if len(blockData) > 0 {
+			t.Error("Extra data remaining")
 		}
 		if block.GetHeight() != test.BlockHeight {
 			t.Errorf("incorrect block height in testnet block %d", test.BlockHeight)

--- a/parser/block_test.go
+++ b/parser/block_test.go
@@ -19,16 +19,21 @@ import (
 )
 
 func TestBlockParser(t *testing.T) {
-	// These (valid on testnet) correspond to the transactions in testdata/blocks
-	var txhashes = []string{
-		"81096ff101a4f01d25ffd34a446bee4368bd46c233a59ac0faf101e1861c6b22",
-		"921dc41bef3a0d887c615abac60a29979efc8b4bbd3d887caeb6bb93501bde8e",
-		"d8e4c336ffa69dacaa4e0b4eaf8e3ae46897f1930a573c10b53837a03318c980",
-		"4d5ccbfc6984680c481ff5ce145b8a93d59dfea90c150dfa45c938ab076ee5b2",
-		"df2b03619d441ce3d347e9278d87618e975079d0e235dfb3b3d8271510f707aa",
-		"8d2593edfc328fa637b4ac91c7d569ee922bb9a6fda7cea230e92deb3ae4b634",
+	// These (valid on testnet) correspond to the transactions in testdata/blocks;
+	// for each block, the hashes for the tx within that block.
+	var txhashes = [][]string{
+		{
+			"81096ff101a4f01d25ffd34a446bee4368bd46c233a59ac0faf101e1861c6b22",
+		}, {
+			"921dc41bef3a0d887c615abac60a29979efc8b4bbd3d887caeb6bb93501bde8e",
+		}, {
+			"d8e4c336ffa69dacaa4e0b4eaf8e3ae46897f1930a573c10b53837a03318c980",
+			"4d5ccbfc6984680c481ff5ce145b8a93d59dfea90c150dfa45c938ab076ee5b2",
+		}, {
+			"df2b03619d441ce3d347e9278d87618e975079d0e235dfb3b3d8271510f707aa",
+			"8d2593edfc328fa637b4ac91c7d569ee922bb9a6fda7cea230e92deb3ae4b634",
+		},
 	}
-	txindex := 0
 	testBlocks, err := os.Open("../testdata/blocks")
 	if err != nil {
 		t.Fatal(err)
@@ -36,7 +41,7 @@ func TestBlockParser(t *testing.T) {
 	defer testBlocks.Close()
 
 	scan := bufio.NewScanner(testBlocks)
-	for i := 0; scan.Scan(); i++ {
+	for blockindex := 0; scan.Scan(); blockindex++ {
 		blockDataHex := scan.Text()
 		blockData, err := hex.DecodeString(blockDataHex)
 		if err != nil {
@@ -44,46 +49,92 @@ func TestBlockParser(t *testing.T) {
 			continue
 		}
 
-		block := NewBlock()
-		blockData, err = block.ParseFromSlice(blockData)
-		if err != nil {
-			t.Error(errors.Wrap(err, fmt.Sprintf("parsing block %d", i)))
-			continue
-		}
-		if len(blockData) > 0 {
-			t.Error("Extra data remaining")
+		// This is just a sanity check of the test:
+		if int(blockData[1487]) != len(txhashes[blockindex]) {
+			t.Error("wrong number of transactions, test broken?")
 		}
 
-		// Some basic sanity checks
-		if block.hdr.Version != 4 {
-			t.Error("Read wrong version in a test block.")
-			break
-		}
-		if block.GetVersion() != 4 {
-			t.Error("Read wrong version in a test block.")
-			break
-		}
-		if block.GetTxCount() < 1 {
-			t.Error("No transactions in block")
-			break
-		}
-		if len(block.Transactions()) != block.GetTxCount() {
-			t.Error("Number of transactions mismatch")
-			break
-		}
-		if block.HasSaplingTransactions() {
-			t.Error("Unexpected Saping tx")
-			break
-		}
-		for _, tx := range block.Transactions() {
-			if tx.HasSaplingElements() {
+		// Make a copy of just the transactions alone, which,
+		// for these blocks, start just beyond the header and
+		// the one-byte nTx value, which is offset 1488.
+		transactions := make([]byte, len(blockData[1488:]))
+		copy(transactions, blockData[1488:])
+
+		// Each iteration of this loop appends the block's original
+		// transactions, so we build an ever-larger block. The loop
+		// limit is arbitrary, but make sure we get into double-digit
+		// transaction counts (compact integer).
+		for i := 0; i < 264; i++ {
+			b := blockData
+			block := NewBlock()
+			b, err = block.ParseFromSlice(b)
+			if err != nil {
+				t.Error(errors.Wrap(err, fmt.Sprintf("parsing block %d", i)))
+				continue
+			}
+			if len(b) > 0 {
+				t.Error("Extra data remaining")
+			}
+
+			// Some basic sanity checks
+			if block.hdr.Version != 4 {
+				t.Error("Read wrong version in a test block.")
+				break
+			}
+			if block.GetVersion() != 4 {
+				t.Error("Read wrong version in a test block.")
+				break
+			}
+			if block.GetTxCount() < 1 {
+				t.Error("No transactions in block")
+				break
+			}
+			if len(block.Transactions()) != block.GetTxCount() {
+				t.Error("Number of transactions mismatch")
+				break
+			}
+			if block.GetTxCount() != len(txhashes[blockindex])*(i+1) {
+				t.Error("Unexpected number of transactions")
+			}
+			if block.HasSaplingTransactions() {
 				t.Error("Unexpected Saping tx")
 				break
 			}
-			if hex.EncodeToString(tx.GetDisplayHash()) != txhashes[txindex] {
-				t.Error("incorrect tx hash")
+			for txindex, tx := range block.Transactions() {
+				if tx.HasSaplingElements() {
+					t.Error("Unexpected Saping tx")
+					break
+				}
+				expectedHash := txhashes[blockindex][txindex%len(txhashes[blockindex])]
+				if hex.EncodeToString(tx.GetDisplayHash()) != expectedHash {
+					t.Error("incorrect tx hash")
+				}
 			}
-			txindex++
+			// Keep appending the original transactions, which is unrealistic
+			// because the coinbase is being replicated, but it works; first do
+			// some surgery to the transaction count (see DarksideApplyStaged()).
+			for j := 0; j < len(txhashes[blockindex]); j++ {
+				nTxFirstByte := blockData[1487]
+				switch {
+				case nTxFirstByte < 252:
+					blockData[1487]++
+				case nTxFirstByte == 252:
+					// incrementing to 253, requires "253" followed by 2-byte length,
+					// extend the block by two bytes, shift existing transaction bytes
+					blockData = append(blockData, 0, 0)
+					copy(blockData[1490:], blockData[1488:len(blockData)-2])
+					blockData[1487] = 253
+					blockData[1488] = 253
+					blockData[1489] = 0
+				case nTxFirstByte == 253:
+					blockData[1488]++
+					if blockData[1488] == 0 {
+						// wrapped around
+						blockData[1489]++
+					}
+				}
+			}
+			blockData = append(blockData, transactions...)
 		}
 	}
 }

--- a/parser/internal/bytestring/bytestring_test.go
+++ b/parser/internal/bytestring/bytestring_test.go
@@ -185,6 +185,8 @@ func TestString_ReadBytes(t *testing.T) {
 	}
 }
 
+// compact sizes are little-endian (least significant byte first, lower memory addr),
+// see https://en.bitcoin.it/wiki/Protocol_documentation#Variable_length_integer
 var readCompactSizeTests = []struct {
 	s        String
 	ok       bool

--- a/parser/transaction_test.go
+++ b/parser/transaction_test.go
@@ -51,7 +51,7 @@ type outputTestVector struct {
 
 type txTestVector struct {
 	// Sprout and Sapling
-	txid, header, nVersionGroupId, nLockTime, nExpiryHeight string
+	txid, header, nVersionGroupID, nLockTime, nExpiryHeight string
 	vin, vout                                               [][]string
 	vJoinSplits                                             []joinSplitTestVector
 	joinSplitPubKey, joinSplitSig                           string
@@ -69,7 +69,7 @@ var zip143tests = []txTestVector{
 		// Test vector 1
 		txid:            "f0b22277ac851b5f4df590fe6a128aad9d0ce8063235eb2b328c2dc6a23c1ec5",
 		header:          "03000080",
-		nVersionGroupId: "7082c403",
+		nVersionGroupID: "7082c403",
 		nLockTime:       "481cdd86",
 		nExpiryHeight:   "b3cc4318",
 		vin:             nil,
@@ -83,7 +83,7 @@ var zip143tests = []txTestVector{
 		//raw: "we have some raw data for this tx, which this comment is too small to contain",
 		txid:            "39fe585a56b005f568c3171d22afa916e946e2a8aff5971d58ee8a6fc1482059",
 		header:          "03000080",
-		nVersionGroupId: "7082c403",
+		nVersionGroupID: "7082c403",
 		nLockTime:       "97b0e4e4",
 		nExpiryHeight:   "c705fc05",
 		vin: [][]string{
@@ -242,9 +242,9 @@ func subTestCommonBlockMeta(tt *txTestVector, tx *Transaction, t *testing.T, cas
 		return false
 	}
 
-	versionGroupBytes, _ := hex.DecodeString(tt.nVersionGroupId)
+	versionGroupBytes, _ := hex.DecodeString(tt.nVersionGroupID)
 	versionGroup := binary.LittleEndian.Uint32(versionGroupBytes)
-	if versionGroup != tx.nVersionGroupId {
+	if versionGroup != tx.nVersionGroupID {
 		t.Errorf("Test %d: unexpected versionGroupId", caseNum)
 		return false
 	}
@@ -514,7 +514,7 @@ var zip243tests = []txTestVector{
 	{
 		txid:            "5fc4867a1b8bd5ab709799adf322a85d10607e053726d5f5ab4b1c9ab897e6bc",
 		header:          "04000080",
-		nVersionGroupId: "85202f89",
+		nVersionGroupID: "85202f89",
 		vin:             nil,
 		vout: [][]string{
 			{"e7719811893e0000", "095200ac6551ac636565"},
@@ -617,7 +617,7 @@ var zip243tests = []txTestVector{
 	{
 		txid:            "6732cf8d67aac5b82a2a0f0217a7d4aa245b2adb0b97fd2d923dfc674415e221",
 		header:          "04000080",
-		nVersionGroupId: "85202f89",
+		nVersionGroupID: "85202f89",
 		vin: [][]string{
 			{"56e551406a7ee8355656a21e43e38ce129fdadb759eddfa08f00fc8e567cef93", "c6792d01", "0763656300ac63ac", "8df04245"},
 			{"1a33590d3e8cf49b2627218f0c292fa66ada945fa55bb23548e33a83a562957a", "3149a993", "086a5352516a65006a", "78d97ce4"},

--- a/walletrpc/darkside.pb.go
+++ b/walletrpc/darkside.pb.go
@@ -630,8 +630,8 @@ type DarksideStreamerClient interface {
 	// StageBlocksCreate is like the previous two, except it creates 'count'
 	// empty blocks at consecutive heights starting at height 'height'. The
 	// 'nonce' is part of the header, so it contributes to the block hash; this
-	// lets you create two fake blocks with the same transactions (or no
-	// transactions) and same height, with two different hashes.
+	// lets you create identical blocks (same transactions and height), but with
+	// different hashes.
 	StageBlocksCreate(ctx context.Context, in *DarksideEmptyBlocks, opts ...grpc.CallOption) (*Empty, error)
 	// StageTransactionsStream stores the given transaction-height pairs in the
 	// staging area until ApplyStaged() is called. Note that these transactions
@@ -639,20 +639,21 @@ type DarksideStreamerClient interface {
 	// appear in a "mined" block (contained in the active blockchain presented
 	// by the mock zcashd).
 	StageTransactionsStream(ctx context.Context, opts ...grpc.CallOption) (DarksideStreamer_StageTransactionsStreamClient, error)
-	// StageTransactions is the same except the transactions are fetched
-	// from the given url. They are all staged into the block at the given
-	// height. Staging transactions at multiple different heights requires
-	// multiple calls.
+	// StageTransactions is the same except the transactions are fetched from
+	// the given url. They are all staged into the block at the given height.
+	// Staging transactions to different heights requires multiple calls.
 	StageTransactions(ctx context.Context, in *DarksideTransactionsURL, opts ...grpc.CallOption) (*Empty, error)
 	// ApplyStaged iterates the list of blocks that were staged by the
 	// StageBlocks*() gRPCs, in the order they were staged, and "merges" each
 	// into the active, working blocks list that the mock zcashd is presenting
-	// to lightwalletd. The resulting working block list can't have gaps; if the
-	// working block range is 1000-1006, and the staged block range is 1003-1004,
-	// the resulting range is 1000-1004, with 1000-1002 unchanged, blocks
-	// 1003-1004 from the new range, and 1005-1006 dropped. After merging all
-	// blocks, ApplyStaged() appends staged transactions (in the order received)
-	// into each one's corresponding block. The staging area is then cleared.
+	// to lightwalletd. Even as each block is applied, the active list can't
+	// have gaps; if the active block range is 1000-1006, and the staged block
+	// range is 1003-1004, the resulting range is 1000-1004, with 1000-1002
+	// unchanged, blocks 1003-1004 from the new range, and 1005-1006 dropped.
+	//
+	// After merging all blocks, ApplyStaged() appends staged transactions (in
+	// the order received) into each one's corresponding (by height) block
+	// The staging area is then cleared.
 	//
 	// The argument specifies the latest block height that mock zcashd reports
 	// (i.e. what's returned by GetLatestBlock). Note that ApplyStaged() can
@@ -853,8 +854,8 @@ type DarksideStreamerServer interface {
 	// StageBlocksCreate is like the previous two, except it creates 'count'
 	// empty blocks at consecutive heights starting at height 'height'. The
 	// 'nonce' is part of the header, so it contributes to the block hash; this
-	// lets you create two fake blocks with the same transactions (or no
-	// transactions) and same height, with two different hashes.
+	// lets you create identical blocks (same transactions and height), but with
+	// different hashes.
 	StageBlocksCreate(context.Context, *DarksideEmptyBlocks) (*Empty, error)
 	// StageTransactionsStream stores the given transaction-height pairs in the
 	// staging area until ApplyStaged() is called. Note that these transactions
@@ -862,20 +863,21 @@ type DarksideStreamerServer interface {
 	// appear in a "mined" block (contained in the active blockchain presented
 	// by the mock zcashd).
 	StageTransactionsStream(DarksideStreamer_StageTransactionsStreamServer) error
-	// StageTransactions is the same except the transactions are fetched
-	// from the given url. They are all staged into the block at the given
-	// height. Staging transactions at multiple different heights requires
-	// multiple calls.
+	// StageTransactions is the same except the transactions are fetched from
+	// the given url. They are all staged into the block at the given height.
+	// Staging transactions to different heights requires multiple calls.
 	StageTransactions(context.Context, *DarksideTransactionsURL) (*Empty, error)
 	// ApplyStaged iterates the list of blocks that were staged by the
 	// StageBlocks*() gRPCs, in the order they were staged, and "merges" each
 	// into the active, working blocks list that the mock zcashd is presenting
-	// to lightwalletd. The resulting working block list can't have gaps; if the
-	// working block range is 1000-1006, and the staged block range is 1003-1004,
-	// the resulting range is 1000-1004, with 1000-1002 unchanged, blocks
-	// 1003-1004 from the new range, and 1005-1006 dropped. After merging all
-	// blocks, ApplyStaged() appends staged transactions (in the order received)
-	// into each one's corresponding block. The staging area is then cleared.
+	// to lightwalletd. Even as each block is applied, the active list can't
+	// have gaps; if the active block range is 1000-1006, and the staged block
+	// range is 1003-1004, the resulting range is 1000-1004, with 1000-1002
+	// unchanged, blocks 1003-1004 from the new range, and 1005-1006 dropped.
+	//
+	// After merging all blocks, ApplyStaged() appends staged transactions (in
+	// the order received) into each one's corresponding (by height) block
+	// The staging area is then cleared.
 	//
 	// The argument specifies the latest block height that mock zcashd reports
 	// (i.e. what's returned by GetLatestBlock). Note that ApplyStaged() can

--- a/walletrpc/darkside.proto
+++ b/walletrpc/darkside.proto
@@ -69,8 +69,8 @@ service DarksideStreamer {
     // StageBlocksCreate is like the previous two, except it creates 'count'
     // empty blocks at consecutive heights starting at height 'height'. The
     // 'nonce' is part of the header, so it contributes to the block hash; this
-    // lets you create two fake blocks with the same transactions (or no
-    // transactions) and same height, with two different hashes.
+    // lets you create identical blocks (same transactions and height), but with
+    // different hashes.
     rpc StageBlocksCreate(DarksideEmptyBlocks) returns (Empty) {}
 
     // StageTransactionsStream stores the given transaction-height pairs in the
@@ -80,21 +80,22 @@ service DarksideStreamer {
     // by the mock zcashd).
     rpc StageTransactionsStream(stream RawTransaction) returns (Empty) {}
 
-    // StageTransactions is the same except the transactions are fetched
-    // from the given url. They are all staged into the block at the given
-    // height. Staging transactions at multiple different heights requires
-    // multiple calls.
+    // StageTransactions is the same except the transactions are fetched from
+    // the given url. They are all staged into the block at the given height.
+    // Staging transactions to different heights requires multiple calls.
     rpc StageTransactions(DarksideTransactionsURL) returns (Empty) {}
 
     // ApplyStaged iterates the list of blocks that were staged by the
     // StageBlocks*() gRPCs, in the order they were staged, and "merges" each
     // into the active, working blocks list that the mock zcashd is presenting
-    // to lightwalletd. The resulting working block list can't have gaps; if the
-    // working block range is 1000-1006, and the staged block range is 1003-1004,
-    // the resulting range is 1000-1004, with 1000-1002 unchanged, blocks
-    // 1003-1004 from the new range, and 1005-1006 dropped. After merging all
-    // blocks, ApplyStaged() appends staged transactions (in the order received)
-    // into each one's corresponding block. The staging area is then cleared.
+    // to lightwalletd. Even as each block is applied, the active list can't
+    // have gaps; if the active block range is 1000-1006, and the staged block
+    // range is 1003-1004, the resulting range is 1000-1004, with 1000-1002
+    // unchanged, blocks 1003-1004 from the new range, and 1005-1006 dropped.
+    //
+    // After merging all blocks, ApplyStaged() appends staged transactions (in
+    // the order received) into each one's corresponding (by height) block
+    // The staging area is then cleared.
     //
     // The argument specifies the latest block height that mock zcashd reports
     // (i.e. what's returned by GetLatestBlock). Note that ApplyStaged() can


### PR DESCRIPTION
The darksidewalletd code has a restriction that a block can have at most 252 transactions. This is because the number of transactions in a block is encoded as a variable integer (aka compact integer), and the serialization of 253 or greater requires more than one byte, so it's a little complex and messy, so we haven't bothered. But this doesn't allow us to stress-test the lightwalletd and the wallets under the condition that there are more than 252 transactions in a block. Merging this PR will allow https://github.com/zcash/lightwalletd/issues/267 to proceed (creating actual tests). This PR also adds a bit more error detection to block parsing.

I tested this manually:
```
# start darksidewalletd
curl -s https://raw.githubusercontent.com/zcash-hackworks/darksidewalletd-test-data/master/transactions/t-shielded-spend.txt >t-shielded-spend.txt
mkdir blocks
for i in {1..253};do cat t-shielded-spend.txt >>blocks/1000.txt;done
go run testtools/genblocks/main.go >block-list # without this PR, this will fail
utils/submitblocks.sh 1000 block-list
```
Then verify that there are 253 transactions in this block (the last "index" should be "253"):

`grpcurl -plaintext -d '{"height":1000}' localhost:9067 cash.z.wallet.sdk.rpc.CompactTxStreamer/GetBlock`

Probably good to try the same with 254 and 255, to explore the edge cases.