### PR TITLE
Fixes GetTransaction returning base64 hex values.

### DIFF
--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -262,7 +262,7 @@ func (tg *testgettx) Context() context.Context {
 }
 
 func (tg *testgettx) Send(tx *walletrpc.RawTransaction) error {
-	if !bytes.Equal(tx.Data, []byte(hex.EncodeToString(rawTxData[0]))) {
+	if !bytes.Equal(tx.Data, rawTxData[0]) {
 		testT.Fatal("mismatch transaction data")
 	}
 	if tx.Height != 1234567 {

--- a/frontend/service.go
+++ b/frontend/service.go
@@ -180,8 +180,12 @@ func (s *lwdStreamer) GetTransaction(ctx context.Context, txf *walletrpc.TxFilte
 		if err != nil {
 			return nil, err
 		}
+		txBytes, err := hex.DecodeString(txinfo.Hex)
+		if err != nil {
+			return nil, err
+		}
 		return &walletrpc.RawTransaction{
-			Data:   []byte(txinfo.Hex),
+			Data:   txBytes,
 			Height: uint64(txinfo.Height),
 		}, nil
 	}


### PR DESCRIPTION
Addresses the transaction error that we pin-pointed on the call.

- The `hex.DecodeString` was [removed](https://github.com/zcash/lightwalletd/commit/a4f968823fdd66420df2ffafa083bc19054aeca2#diff-628105f4a59fdf3bdae4d418810e5cd4L172) in commit a4f968823fdd66420df2ffafa083bc19054aeca2
- This resulted in the hex value of the transaction that was returned from zcashd getting base64 encoded, rather than the binary represented by the hex getting base64 encoded