### PR TITLE
add error check to StageBlocksStream

### DIFF
--- a/frontend/service.go
+++ b/frontend/service.go
@@ -331,6 +331,9 @@ func (s *DarksideStreamer) StageTransactionsStream(tx walletrpc.DarksideStreamer
 			tx.SendAndClose(&walletrpc.Empty{})
 			return nil
 		}
+		if err != nil {
+			return err
+		}
 		err = common.DarksideStageTransaction(int(transaction.Height), transaction.Data)
 		if err != nil {
 			return err


### PR DESCRIPTION
Add an error check to `StageTransactionsStream`'s call to `tx.Recv()`. The error that's most often returned here is probably timeout (deadline reached). Without this change, the lightwalletd crashes with a SIGSEGV fault.