### PR TITLE
Added option to provide Zcashd RPC parameters from flags

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -33,6 +33,10 @@ type Options struct {
 	LogLevel            uint64 `json:"log_level,omitempty"`
 	LogFile             string `json:"log_file,omitempty"`
 	ZcashConfPath       string `json:"zcash_conf,omitempty"`
+	RPCUser             string `json:"rpcuser"`
+	RPCPassword         string `json:"rpcpassword"`
+	RPCHost             string `json:"rpchost"`
+	RPCPort             string `json:"rpcport"`
 	NoTLSVeryInsecure   bool   `json:"no_tls_very_insecure,omitempty"`
 	GenCertVeryInsecure bool   `json:"gen_cert_very_insecure,omitempty"`
 	Redownload          bool   `json:"redownload"`

--- a/frontend/rpc_client.go
+++ b/frontend/rpc_client.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/pkg/errors"
+	"github.com/zcash/lightwalletd/common"
 	ini "gopkg.in/ini.v1"
 )
 
@@ -17,6 +18,19 @@ func NewZRPCFromConf(confPath interface{}) (*rpcclient.Client, error) {
 	connCfg, err := connFromConf(confPath)
 	if err != nil {
 		return nil, err
+	}
+	return rpcclient.New(connCfg, nil)
+}
+
+// NewZRPCFromFlags gets zcashd rpc connection information from provided flags.
+func NewZRPCFromFlags(opts *common.Options) (*rpcclient.Client, error) {
+	// Connect to local Zcash RPC server using HTTP POST mode.
+	connCfg := &rpcclient.ConnConfig{
+		Host:         net.JoinHostPort(opts.RPCHost, opts.RPCPort),
+		User:         opts.RPCUser,
+		Pass:         opts.RPCPassword,
+		HTTPPostMode: true, // Zcash only supports HTTP POST mode
+		DisableTLS:   true, // Zcash does not provide TLS by default
 	}
 	return rpcclient.New(connCfg, nil)
 }


### PR DESCRIPTION
What
This change allows the configuration of the zcash rpc credentials to come from flags, and by the inclusion of Viper for options parsing, environmental variables.

Why
The reason this is needed is the lightwalletd and zcashd instances won't necessarily be the same file system with access to the same files.

How
The startup logic checks if all 4 parameters are present:
- rpcuser
- rpcpassword
- rpchost
- rpcport

If all four are not provided, the logic falls back to looking for a zcash.conf file and processes that instead.

Examples of usage

Current use, zcash.conf is found in the current working directory and used.
```
$ cat zcash.conf 
rpcuser=zcashrpc
rpcpassword=notsecure
rpcbind=192.168.86.41
rpcport=38232
$ ./lightwalletd --no-tls-very-insecure --log-file /dev/stdout --data-dir $(pwd)
```

Delete zcash.conf and it fails to start with an expected error message.
```
$ rm zcash.conf 
$ ./lightwalletd --no-tls-very-insecure --log-file /dev/stdout --data-dir $(pwd)
Using config file: /home/bwilson/go/src/github.com/zcash/lightwalletd/lightwalletd.yml

  ** File does not exist: ./zcash.conf
```

Use the new flags to provide rpc connection information
```
$ ./lightwalletd --no-tls-very-insecure --log-file /dev/stdout --data-dir $(pwd) --rpcuser zcashrpc --rpcpassword=notsecure --rpchost 192.168.86.41 --rpcport 38232
{"app":"lightwalletd","buildDate":"2020-06-08","buildUser":"bwilson","gitCommit":"63f01502e8de76bcf57018b1c478e26993a82b2d",
"level":"info","msg":"Starting gRPC server version v0.4.0-4-g63f0150 on 127.0.0.1:9067","time":"2020-06-08T09:13:21-04:00"}
...
```

Use environmental variables to configure lightwalletd
```
$ RPCUSER=zcashrpc RPCPASSWORD=notsecure RPCHOST=192.168.86.41 RPCPORT=38232 ./lightwalletd --no-tls-very-insecure --log-fil
e /dev/stdout --data-dir $(pwd)
{"app":"lightwalletd","buildDate":"2020-06-08","buildUser":"bwilson","gitCommit":"63f01502e8de76bcf57018b1c478e26993a82b2d",
"level":"info","msg":"Starting gRPC server version v0.4.0-4-g63f0150 on 127.0.0.1:9067","time":"2020-06-08T09:13:10-04:00"}
...
```

