### PR TITLE
Added Tekton definitions for docker tag builds

### DIFF
--- a/kubernetes/tekton/README.md
+++ b/kubernetes/tekton/README.md
@@ -1,0 +1,5 @@
+# Tekton CI
+
+The configurations in this directory are for automating lightwalletd operations using Tekton.
+
+Currently new tags will trigger a docker build and push to https://hub.docker.com/r/electriccoinco/lightwalletd

--- a/kubernetes/tekton/lightwalletd-tag-pipeline.yml
+++ b/kubernetes/tekton/lightwalletd-tag-pipeline.yml
@@ -1,0 +1,28 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: lightwalletd-tag-pipeline
+spec:
+  resources:
+    - name: source
+      type: git
+    - name: cloudlog
+      type: cloudEvent
+    - name: lightwalletd-image
+      type: image
+  params:
+    - name: tagName
+  tasks:
+    - name: lightwalletd-build-docker-image
+      taskRef:
+        name: build-docker-image-from-git-source
+      resources:
+        inputs:
+          - name: docker-source
+            resource: source
+        outputs:
+          - name: builtImage
+            resource: lightwalletd-image
+          - name: notification
+            resource: cloudlog

--- a/kubernetes/tekton/triggerbinding.yml
+++ b/kubernetes/tekton/triggerbinding.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: lightwalletd-tag-binding
+spec:
+  params:
+    - name: dockerImageName
+      value: electriccoinco/lightwalletd
+    - name: tagName
+      value: $(body.extensions.tag)
+    - name: gitRepositoryURL
+      value: $(body.repository.clone_url)

--- a/kubernetes/tekton/triggertemplate.yml
+++ b/kubernetes/tekton/triggertemplate.yml
@@ -1,0 +1,43 @@
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: lightwalletd-tag-pipeline-template
+spec:
+  params:
+    - name: gitRepositoryURL
+      description: Git repo url
+    - name: tagName
+      description: Release tag name      
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: lightwalletd-tag-pipeline-
+      spec:
+        serviceAccountName: ecc-tekton
+        pipelineRef:
+          name: lightwalletd-tag-pipeline
+        resources:
+          - name: source
+            resourceSpec:
+              type: git
+              params:
+                - name: revision
+                  value: $(params.tagName)
+                - name: url
+                  value: $(params.gitRepositoryURL)
+          - name: lightwalletd-image
+            resourceSpec:
+              type: image
+              params:
+                - name: url
+                  value: electriccoinco/lightwalletd:$(params.tagName)
+          - name: cloudlog
+            resourceRef:
+              name: cloudlog
+        params:
+          - name: gitRepositoryURL
+            value: $(params.gitRepositoryURL)
+          - name: tagName
+            value: $(params.tagName)

--- a/kubernetes/tekton/triggertemplate.yml
+++ b/kubernetes/tekton/triggertemplate.yml
@@ -27,6 +27,8 @@ spec:
                   value: $(params.tagName)
                 - name: url
                   value: $(params.gitRepositoryURL)
+                - name: refspec
+                  value: "+refs/tags/*:refs/remotes/origin/tags/*"
           - name: lightwalletd-image
             resourceSpec:
               type: image
@@ -34,8 +36,11 @@ spec:
                 - name: url
                   value: electriccoinco/lightwalletd:$(params.tagName)
           - name: cloudlog
-            resourceRef:
-              name: cloudlog
+            resourceSpec:
+              type: cloudEvent
+              params:
+                - name: targetURI
+                  value: http://cloudlog:8080/inbox
         params:
           - name: gitRepositoryURL
             value: $(params.gitRepositoryURL)


### PR DESCRIPTION
The PR defines a single task pipeline for Tekton.

See `kubernetes/tekton/README.md` for tasks and pipeline events.

But basically, when a new tag event occurs, build a new Docker image and upload it, with the tag, to https://hub.docker.com/r/electriccoinco/lightwalletd 

