### PR TITLE
gracefully handle syncing zcashd (no REORG)

### DIFF
--- a/common/cache.go
+++ b/common/cache.go
@@ -37,6 +37,13 @@ func (c *BlockCache) GetNextHeight() int {
 	return c.nextBlock
 }
 
+// GetFirstHeight returns the height of the lowest block (usually Sapling activation).
+func (c *BlockCache) GetFirstHeight() int {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	return c.firstBlock
+}
+
 // GetLatestHash returns the hash (block ID) of the most recent (highest) known block.
 func (c *BlockCache) GetLatestHash() []byte {
 	c.mutex.RLock()

--- a/common/common.go
+++ b/common/common.go
@@ -215,11 +215,18 @@ func BlockIngestor(c *BlockCache, rep int) {
 		retryCount = 0
 		if block == nil {
 			// No block at this height.
+			if height == c.GetFirstHeight() {
+				Log.Info("Waiting for zcashd height to reach Sapling activation height ",
+					"(", c.GetFirstHeight(), ")...")
+				reorgCount = 0
+				Sleep(20 * time.Second)
+				continue
+			}
 			if wait {
 				// Wait a bit then retry the same height.
 				c.Sync()
 				if lastHeightLogged+1 != height {
-					Log.Info("Ingestor: waiting for block: ", height)
+					Log.Info("Ingestor waiting for block: ", height)
 					lastHeightLogged = height - 1
 				}
 				Sleep(2 * time.Second)


### PR DESCRIPTION
Closes #292. Lightwalletd will retry every 20 seconds, and log a message like:
```
{"app":"lightwalletd","level":"info","msg":"Waiting for zcashd height to reach Sapling activation height (280000)...","time":"2020-06-25T14:23:06-06:00"}
```
Once the zcashd reaches the sapling activation height, both will sync together smoothly.