### PR TITLE
refactor Reverse(), no functional changes

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -318,16 +318,6 @@ func GetBlockRange(cache *BlockCache, blockOut chan<- *walletrpc.CompactBlock, e
 	errOut <- nil
 }
 
-// Reverse the given byte slice, returning a slice pointing to new data;
-// the input slice is unchanged.
-func Reverse(a []byte) []byte {
-	r := make([]byte, len(a), len(a))
-	for left, right := 0, len(a)-1; left < right; left, right = left+1, right-1 {
-		r[left], r[right] = a[right], a[left]
-	}
-	return r
-}
-
 func displayHash(hash []byte) string {
-	return hex.EncodeToString(Reverse(hash))
+	return hex.EncodeToString(parser.Reverse(hash))
 }

--- a/frontend/service.go
+++ b/frontend/service.go
@@ -98,7 +98,7 @@ func (s *lwdStreamer) GetTaddressTxids(addressBlockFilter *walletrpc.Transparent
 		txid, _ := hex.DecodeString(txidstr)
 		// Txid is read as a string, which is in big-endian order. But when converting
 		// to bytes, it should be little-endian
-		tx, err := s.GetTransaction(timeout, &walletrpc.TxFilter{Hash: common.Reverse(txid)})
+		tx, err := s.GetTransaction(timeout, &walletrpc.TxFilter{Hash: parser.Reverse(txid)})
 		if err != nil {
 			common.Log.Errorf("GetTransaction error: %s", err.Error())
 			return err
@@ -377,7 +377,7 @@ func (s *lwdStreamer) GetMempoolTx(exclude *walletrpc.Exclude, resp walletrpc.Co
 	}
 	excludeHex := make([]string, len(exclude.Txid))
 	for i := 0; i < len(exclude.Txid); i++ {
-		excludeHex[i] = hex.EncodeToString(common.Reverse(exclude.Txid[i]))
+		excludeHex[i] = hex.EncodeToString(parser.Reverse(exclude.Txid[i]))
 	}
 	for _, txid := range MempoolFilter(mempoolList, excludeHex) {
 		tx := (*mempoolMap)[txid]

--- a/parser/block_header.go
+++ b/parser/block_header.go
@@ -209,13 +209,8 @@ func (hdr *BlockHeader) GetDisplayHash() []byte {
 	digest := sha256.Sum256(serializedHeader)
 	digest = sha256.Sum256(digest[:])
 
-	// Reverse byte order
-	for i := 0; i < len(digest)/2; i++ {
-		j := len(digest) - 1 - i
-		digest[i], digest[j] = digest[j], digest[i]
-	}
-
-	hdr.cachedHash = digest[:]
+	// Convert to big-endian
+	hdr.cachedHash = Reverse(digest[:])
 	return hdr.cachedHash
 }
 
@@ -234,14 +229,7 @@ func (hdr *BlockHeader) GetEncodableHash() []byte {
 	return digest[:]
 }
 
-// GetDisplayPrevHash returns the block hash in
+// GetDisplayPrevHash returns the block hash in big-endian order.
 func (hdr *BlockHeader) GetDisplayPrevHash() []byte {
-	rhash := make([]byte, len(hdr.HashPrevBlock))
-	copy(rhash, hdr.HashPrevBlock)
-	// Reverse byte order
-	for i := 0; i < len(rhash)/2; i++ {
-		j := len(rhash) - 1 - i
-		rhash[i], rhash[j] = rhash[j], rhash[i]
-	}
-	return rhash
+	return Reverse(hdr.HashPrevBlock)
 }

--- a/parser/transaction.go
+++ b/parser/transaction.go
@@ -271,28 +271,22 @@ func (p *joinSplit) ParseFromSlice(data []byte) ([]byte, error) {
 // Transaction encodes a full (zcashd) transaction.
 type Transaction struct {
 	*rawTransaction
-	rawBytes []byte
-	txID     []byte
+	rawBytes   []byte
+	cachedTxID []byte // cached for performance
 }
 
 // GetDisplayHash returns the transaction hash in big-endian display order.
 func (tx *Transaction) GetDisplayHash() []byte {
-	if tx.txID != nil {
-		return tx.txID
+	if tx.cachedTxID != nil {
+		return tx.cachedTxID
 	}
 
 	// SHA256d
 	digest := sha256.Sum256(tx.rawBytes)
 	digest = sha256.Sum256(digest[:])
-
-	// Reverse byte order
-	for i := 0; i < len(digest)/2; i++ {
-		j := len(digest) - 1 - i
-		digest[i], digest[j] = digest[j], digest[i]
-	}
-
-	tx.txID = digest[:]
-	return tx.txID
+	// Convert to big-endian
+	tx.cachedTxID = Reverse(digest[:])
+	return tx.cachedTxID
 }
 
 // GetEncodableHash returns the transaction hash in little-endian wire format order.

--- a/parser/util.go
+++ b/parser/util.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2019-2020 The Zcash developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+package parser
+
+// Reverse the given byte slice, returning a slice pointing to new data;
+// the input slice is unchanged.
+func Reverse(a []byte) []byte {
+	r := make([]byte, len(a), len(a))
+	for left, right := 0, len(a)-1; left <= right; left, right = left+1, right-1 {
+		r[left], r[right] = a[right], a[left]
+	}
+	return r
+}

--- a/parser/util_test.go
+++ b/parser/util_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2019-2020 The Zcash developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+package parser
+
+import (
+	"testing"
+)
+
+func TestReverse(t *testing.T) {
+	s := make([]byte, 32, 32)
+	for i := 0; i < 32; i++ {
+		s[i] = byte(i)
+	}
+	r := Reverse(s)
+	for i := 0; i < 32; i++ {
+		if r[i] != byte(32-1-i) {
+			t.Fatal("mismatch")
+		}
+	}
+}
+
+// Currently, Reverse() isn't called for odd-length slices, but
+// it should work.
+func TestReverseOdd(t *testing.T) {
+	s := make([]byte, 5, 5)
+	for i := 0; i < 5; i++ {
+		s[i] = byte(i)
+	}
+	r := Reverse(s)
+	for i := 0; i < 5; i++ {
+		if r[i] != byte(5-1-i) {
+			t.Fatal("mismatch")
+		}
+	}
+}


### PR DESCRIPTION
Change three places where the bytes in a slice are reversed, call `Reverse()` instead. Also, add a unit test.