### PR TITLE
GetBlockRange, GetTaddressTxids segfault: add checking for nil args

### DIFF
--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -313,6 +313,44 @@ func TestGetTaddressTxids(t *testing.T) {
 	step = 0
 }
 
+func TestGetTaddressTxidsNilArgs(t *testing.T) {
+	lwd, _ := testsetup()
+
+	{
+		noRange := &walletrpc.TransparentAddressBlockFilter{
+			Range: nil,
+		}
+		err := lwd.GetTaddressTxids(noRange, &testgettx{})
+		if err == nil {
+			t.Fatal("GetBlockRange nil range argument should fail")
+		}
+	}
+	{
+		noStart := &walletrpc.TransparentAddressBlockFilter{
+			Range: &walletrpc.BlockRange{
+				Start: nil,
+				End:   &walletrpc.BlockID{Height: 20},
+			},
+		}
+		err := lwd.GetTaddressTxids(noStart, &testgettx{})
+		if err == nil {
+			t.Fatal("GetBlockRange nil range argument should fail")
+		}
+	}
+	{
+		noEnd := &walletrpc.TransparentAddressBlockFilter{
+			Range: &walletrpc.BlockRange{
+				Start: &walletrpc.BlockID{Height: 30},
+				End:   nil,
+			},
+		}
+		err := lwd.GetTaddressTxids(noEnd, &testgettx{})
+		if err == nil {
+			t.Fatal("GetBlockRange nil range argument should fail")
+		}
+	}
+}
+
 func TestGetBlock(t *testing.T) {
 	testT = t
 	common.RawRequest = getblockStub
@@ -354,7 +392,7 @@ func TestGetBlock(t *testing.T) {
 }
 
 type testgetbrange struct {
-	walletrpc.CompactTxStreamer_GetTaddressTxidsServer
+	walletrpc.CompactTxStreamer_GetBlockRangeServer
 }
 
 func (tg *testgetbrange) Context() context.Context {
@@ -386,6 +424,31 @@ func TestGetBlockRange(t *testing.T) {
 		t.Fatal("GetBlockRange should have failed")
 	}
 	step = 0
+}
+
+func TestGetBlockRangeNilArgs(t *testing.T) {
+	lwd, _ := testsetup()
+
+	{
+		noEnd := &walletrpc.BlockRange{
+			Start: &walletrpc.BlockID{Height: 380640},
+			End:   nil,
+		}
+		err := lwd.GetBlockRange(noEnd, &testgetbrange{})
+		if err == nil {
+			t.Fatal("GetBlockRange nil argument should fail")
+		}
+	}
+	{
+		noStart := &walletrpc.BlockRange{
+			Start: nil,
+			End:   &walletrpc.BlockID{Height: 380640},
+		}
+		err := lwd.GetBlockRange(noStart, &testgetbrange{})
+		if err == nil {
+			t.Fatal("GetBlockRange nil argument should fail")
+		}
+	}
 }
 
 func getblockchaininfoStub(method string, params []json.RawMessage) (json.RawMessage, error) {

--- a/frontend/service.go
+++ b/frontend/service.go
@@ -64,6 +64,15 @@ func (s *lwdStreamer) GetTaddressTxids(addressBlockFilter *walletrpc.Transparent
 		return errors.New("Invalid address")
 	}
 
+	if addressBlockFilter.Range == nil {
+		return errors.New("Must specify block range")
+	}
+	if addressBlockFilter.Range.Start == nil {
+		return errors.New("Must specify a start block height")
+	}
+	if addressBlockFilter.Range.End == nil {
+		return errors.New("Must specify an end block height")
+	}
 	params := make([]json.RawMessage, 1)
 	request := &struct {
 		Addresses []string `json:"addresses"`
@@ -137,6 +146,9 @@ func (s *lwdStreamer) GetBlock(ctx context.Context, id *walletrpc.BlockID) (*wal
 func (s *lwdStreamer) GetBlockRange(span *walletrpc.BlockRange, resp walletrpc.CompactTxStreamer_GetBlockRangeServer) error {
 	blockChan := make(chan *walletrpc.CompactBlock)
 	errChan := make(chan error)
+	if span.Start == nil || span.End == nil {
+		return errors.New("Must specify start and end heights")
+	}
 
 	go common.GetBlockRange(s.cache, blockChan, errChan, int(span.Start.Height), int(span.End.Height))
 


### PR DESCRIPTION
Otherwise, segmentation fault crash is possible. Here are all of the ways to provoke the problem:
````
grpcurl -plaintext -d '{"address":"t1aY1Rc7rm5TRbXJzCxgtBhDeyN7q1bZWVm"}' localhost:9067 cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTaddressTxids
grpcurl -plaintext -d '{"address":"t1aY1Rc7rm5TRbXJzCxgtBhDeyN7q1bZWVm","range":{"start":{"height":0}}}' localhost:9067 cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTaddressTxids
grpcurl -plaintext -d '{"address":"t1aY1Rc7rm5TRbXJzCxgtBhDeyN7q1bZWVm","range":{"end":{"height":0}}}' localhost:9067 cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTaddressTxids
grpcurl -plaintext localhost:9067 cash.z.wallet.sdk.rpc.CompactTxStreamer/GetBlockRange
grpcurl -plaintext -d '{"start":{"height":44}}' localhost:9067 cash.z.wallet.sdk.rpc.CompactTxStreamer/GetBlockRange
grpcurl -plaintext -d '{"end":{"height":44}}' localhost:9067 cash.z.wallet.sdk.rpc.CompactTxStreamer/GetBlockRange
```