### PR TITLE
fix pullblocks.sh for macOS

### DIFF
--- a/utils/pullblocks.sh
+++ b/utils/pullblocks.sh
@@ -2,6 +2,9 @@
 # Usage: ./pullblocks.sh 500000 500100 > blocks.txt
 test $# -ne 2 && { echo usage: $0 start end;exit 1;}
 
-for i in $(seq $1 $2); do
-	zcash-cli getblock $i 0
+let i=$1
+while test $i -le $2
+do
+    zcash-cli getblock $i 0
+    let i++
 done


### PR DESCRIPTION
@pacu discovered that the block heights produced by the "standard" `seq` (sequence of integers) command (used by this script) are of the form `1.0286e+06`. Needless to say, the `zcashd` `getblock` rpc doesn't like this format. This PR generates the block heights using a shell variable (more efficient too).