### PR TITLE
fix database file location bug introduced by PR320

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -219,6 +219,14 @@ func startServer(opts *common.Options) error {
 		os.RemoveAll(filepath.Join(dbPath, chainName))
 	}
 
+	// Temporary, because PR 320 put the db files in the wrong place
+	// (one level too high, directly in "db/" instead of "db/chainname"),
+	// so delete them if they're present. This can be removed sometime.
+	os.Remove(filepath.Join(dbPath, "blocks"))
+	os.Remove(filepath.Join(dbPath, "blocks-corrupted"))
+	os.Remove(filepath.Join(dbPath, "lengths"))
+	os.Remove(filepath.Join(dbPath, "lengths-corrupted"))
+
 	if err := os.MkdirAll(opts.DataDir, 0755); err != nil {
 		os.Stderr.WriteString(fmt.Sprintf("\n  ** Can't create data directory: %s\n\n", opts.DataDir))
 		os.Exit(1)

--- a/common/common.go
+++ b/common/common.go
@@ -68,24 +68,21 @@ type (
 		Status           string // "active"
 	}
 	ConsensusInfo struct { // consensus branch IDs
-		Nextblock string
-		Chaintip  string
+		Nextblock string // example: "e9ff75a6" (canopy)
+		Chaintip  string // example: "e9ff75a6" (canopy)
 	}
 	ZcashdRpcReplyGetblockchaininfo struct {
 		Chain           string
 		Upgrades        map[string]Upgradeinfo
-		Headers         int
+		Blocks          int
 		Consensus       ConsensusInfo
 		EstimatedHeight int
 	}
 
 	// zcashd rpc "getinfo"
 	ZcashdRpcReplyGetinfo struct {
-		Height            int
-		ChainName         string
-		ConsensusBranchID string
-		Build             string
-		Subversion        string
+		Build      string
+		Subversion string
 	}
 
 	// zcashd rpc "getaddresstxids"
@@ -201,10 +198,10 @@ func GetLightdInfo() (*walletrpc.LightdInfo, error) {
 		Version:                 Version,
 		Vendor:                  vendor,
 		TaddrSupport:            true,
-		ChainName:               getinfoReply.ChainName,
+		ChainName:               getblockchaininfoReply.Chain,
 		SaplingActivationHeight: uint64(saplingHeight),
-		ConsensusBranchId:       getinfoReply.ConsensusBranchID,
-		BlockHeight:             uint64(getinfoReply.Height),
+		ConsensusBranchId:       getblockchaininfoReply.Consensus.Chaintip,
+		BlockHeight:             uint64(getblockchaininfoReply.Blocks),
 		GitCommit:               GitCommit,
 		Branch:                  Branch,
 		BuildDate:               BuildDate,

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -84,11 +84,7 @@ func getLightdInfoStub(method string, params []json.RawMessage) (json.RawMessage
 	step++
 	switch method {
 	case "getinfo":
-		r, _ := json.Marshal(&ZcashdRpcReplyGetinfo{
-			Height:            9977,
-			ChainName:         "bugsbunny",
-			ConsensusBranchID: "someid",
-		})
+		r, _ := json.Marshal(&ZcashdRpcReplyGetinfo{})
 		return r, nil
 
 	case "getblockchaininfo":
@@ -102,7 +98,9 @@ func getLightdInfoStub(method string, params []json.RawMessage) (json.RawMessage
 			}
 		}
 		r, _ := json.Marshal(&ZcashdRpcReplyGetblockchaininfo{
-			Headers: 11111,
+			Blocks:    9977,
+			Chain:     "bugsbunny",
+			Consensus: ConsensusInfo{Chaintip: "someid"},
 		})
 		return r, nil
 	}

--- a/common/darkside.go
+++ b/common/darkside.go
@@ -371,7 +371,7 @@ func darksideRawRequest(method string, params []json.RawMessage) (json.RawMessag
 			Upgrades: map[string]Upgradeinfo{
 				"76b809bb": {ActivationHeight: state.startHeight},
 			},
-			Headers:   state.latestHeight,
+			Blocks:    state.latestHeight,
 			Consensus: ConsensusInfo{state.branchID, state.branchID},
 		}
 		return json.Marshal(blockchaininfo)


### PR DESCRIPTION
PR 320 introduced a bug that causes the `blocks` and `lengths` database
files to be located one directory level higher than it they should be.

The bug doesn't cause any functional problem, it only makes the
lightwalletd do more work (re-download the block cache), and it also
makes it not possible to switch between testnet and mainnet.

This patch locates the database files back where they belong.

Note the bug hasn't been deployed yet, so this should only be visible
to developers.