### PR TITLE
fix GetTaddressTxids()

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -87,9 +87,9 @@ type (
 
 	// zcashd rpc "getaddresstxids"
 	ZcashdRpcRequestGetaddresstxids struct {
-		Addresses []string
-		Start     uint64
-		End       uint64
+		Addresses []string `json:"addresses"`
+		Start     uint64   `json:"start"`
+		End       uint64   `json:"end"`
 	}
 
 	// zcashd rpc "z_gettreestate"
@@ -106,10 +106,6 @@ type (
 	}
 
 	// zcashd rpc "getrawtransaction"
-	ZcashdRpcRequestGetrawtransaction struct {
-		Hex    string
-		Height int
-	}
 	ZcashdRpcReplyGetrawtransaction struct {
 		Hex    string
 		Height int

--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -234,7 +234,7 @@ func zcashdrpcStub(method string, params []json.RawMessage) (json.RawMessage, er
 	case "getrawtransaction":
 		switch step {
 		case 2:
-			tx := &common.ZcashdRpcRequestGetrawtransaction{
+			tx := &common.ZcashdRpcReplyGetrawtransaction{
 				Hex:    hex.EncodeToString(rawTxData[0]),
 				Height: 1234567,
 			}


### PR DESCRIPTION
PR #320 broke gRPC GetTaddressTxids():
```
$ grpcurl -plaintext -d '{"address":"t1aY1Rc7rm5TRbXJzCxgtBhDeyN7q1bZWVm","range":{"end":{"height":900000},"start":{"height":1}}}' localhost:9067 cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTaddressTxids
ERROR:
  Code: Unknown
  Message: -5: Addresses is expected to be an array
$ 
```
We inadvertently dropped the `json` tags for struct `ZcashdRpcRequestGetaddresstxids` to map upper-case field names to lower-case, so the `getaddresstxids` rpc sent to zcashd had `Addresses` instead of the required `addresses`.