### PR TITLE
check txid (hash0 length argument, must be 64

### DIFF
--- a/frontend/service.go
+++ b/frontend/service.go
@@ -234,6 +234,9 @@ func (s *lwdStreamer) GetTreeState(ctx context.Context, id *walletrpc.BlockID) (
 // by the zcashd 'getrawtransaction' RPC.
 func (s *lwdStreamer) GetTransaction(ctx context.Context, txf *walletrpc.TxFilter) (*walletrpc.RawTransaction, error) {
 	if txf.Hash != nil {
+		if len(txf.Hash) != 32 {
+			return nil, errors.New("Transaction ID has invalid length")
+		}
 		leHashStringJSON, err := json.Marshal(hex.EncodeToString(parser.Reverse(txf.Hash)))
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
It's unfortunate to hardcode the value 32, but that's already done in many places in the codebase. Note the object whose length we're checking here is a binary transaction ID, not a hex string.