### PR TITLE
Grpc argument checking

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,6 +55,7 @@ var rootCmd = &cobra.Command{
 			GenCertVeryInsecure: viper.GetBool("gen-cert-very-insecure"),
 			DataDir:             viper.GetString("data-dir"),
 			Redownload:          viper.GetBool("redownload"),
+			PingEnable:          viper.GetBool("ping-very-insecure"),
 			Darkside:            viper.GetBool("darkside-very-insecure"),
 			DarksideTimeout:     viper.GetUint64("darkside-timeout"),
 		}
@@ -248,7 +249,7 @@ func startServer(opts *common.Options) error {
 
 	// Compact transaction service initialization
 	{
-		service, err := frontend.NewLwdStreamer(cache, chainName)
+		service, err := frontend.NewLwdStreamer(cache, chainName, opts.PingEnable)
 		if err != nil {
 			common.Log.WithFields(logrus.Fields{
 				"error": err,
@@ -325,6 +326,7 @@ func init() {
 	rootCmd.Flags().Bool("gen-cert-very-insecure", false, "run with self-signed TLS certificate, only for debugging, DO NOT use in production")
 	rootCmd.Flags().Bool("redownload", false, "re-fetch all blocks from zcashd; reinitialize local cache files")
 	rootCmd.Flags().String("data-dir", "/var/lib/lightwalletd", "data directory (such as db)")
+	rootCmd.Flags().Bool("ping-very-insecure", false, "allow Ping GRPC for testing")
 	rootCmd.Flags().Bool("darkside-very-insecure", false, "run with GRPC-controllable mock zcashd for integration testing (shuts down after 30 minutes)")
 	rootCmd.Flags().Int("darkside-timeout", 30, "override 30 minute default darkside timeout")
 
@@ -356,6 +358,8 @@ func init() {
 	viper.SetDefault("redownload", false)
 	viper.BindPFlag("data-dir", rootCmd.Flags().Lookup("data-dir"))
 	viper.SetDefault("data-dir", "/var/lib/lightwalletd")
+	viper.BindPFlag("ping-very-insecure", rootCmd.Flags().Lookup("ping-very-insecure"))
+	viper.SetDefault("ping-very-insecure", false)
 	viper.BindPFlag("darkside-very-insecure", rootCmd.Flags().Lookup("darkside-very-insecure"))
 	viper.SetDefault("darkside-very-insecure", false)
 	viper.BindPFlag("darkside-timeout", rootCmd.Flags().Lookup("darkside-timeout"))

--- a/common/common.go
+++ b/common/common.go
@@ -43,6 +43,7 @@ type Options struct {
 	GenCertVeryInsecure bool   `json:"gen_cert_very_insecure,omitempty"`
 	Redownload          bool   `json:"redownload"`
 	DataDir             string `json:"data_dir"`
+	PingEnable          bool   `json:"ping_enable"`
 	Darkside            bool   `json:"darkside"`
 	DarksideTimeout     uint64 `json:"darkside_timeout"`
 }

--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -37,7 +37,7 @@ const (
 func testsetup() (walletrpc.CompactTxStreamerServer, *common.BlockCache) {
 	os.RemoveAll(unitTestPath)
 	cache := common.NewBlockCache(unitTestPath, unitTestChain, 380640, true)
-	lwd, err := NewLwdStreamer(cache, "main")
+	lwd, err := NewLwdStreamer(cache, "main", false /* enablePing */)
 	if err != nil {
 		os.Stderr.WriteString(fmt.Sprint("NewLwdStreamer failed:", err))
 		os.Exit(1)

--- a/frontend/service.go
+++ b/frontend/service.go
@@ -327,6 +327,11 @@ func (s *lwdStreamer) SendTransaction(ctx context.Context, rawtx *walletrpc.RawT
 }
 
 func getTaddressBalanceZcashdRpc(addressList []string) (*walletrpc.Balance, error) {
+	for _, addr := range addressList {
+		if err := checkTaddress(addr); err != nil {
+			return &walletrpc.Balance{}, err
+		}
+	}
 	params := make([]json.RawMessage, 1)
 	addrList := &common.ZcashdRpcRequestGetaddressbalance{
 		Addresses: addressList,

--- a/frontend/service.go
+++ b/frontend/service.go
@@ -304,6 +304,9 @@ func (s *lwdStreamer) SendTransaction(ctx context.Context, rawtx *walletrpc.RawT
 	// For some reason, the error responses are not JSON
 	if rpcErr != nil {
 		errParts := strings.SplitN(rpcErr.Error(), ":", 2)
+		if len(errParts) < 2 {
+			return nil, errors.New("SendTransaction couldn't parse error code")
+		}
 		errMsg = strings.TrimSpace(errParts[1])
 		errCode, err = strconv.ParseInt(errParts[0], 10, 32)
 		if err != nil {

--- a/walletrpc/service.proto
+++ b/walletrpc/service.proto
@@ -172,6 +172,6 @@ service CompactTxStreamer {
 
     // Return information about this lightwalletd instance and the blockchain
     rpc GetLightdInfo(Empty) returns (LightdInfo) {}
-    // Testing-only
+    // Testing-only, requires lightwalletd --ping-very-insecure (do not enable in production)
     rpc Ping(Duration) returns (PingResponse) {}
 }


### PR DESCRIPTION
Three unrelated changes that will check arguments more carefully, plus guard the `Ping` testing interface behind the use of a command-line flag (not enabled by default).