### PR TITLE
Add vendor flag to Makefile for Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ dep:
 
 # Build binary
 build:
-	GO111MODULE=on go build $(LDFLAGS) 
+	GO111MODULE=on go build $(LDFLAGS) -mod=vendor
 
 build_rel:
 	GO111MODULE=on GOOS=linux go build $(LDFLAGS) 


### PR DESCRIPTION
While issueing a docker build, we noticed some issues from within the Makefile targets:
```
docker build -t electriccoinco/lightwalletd:v0.4.5 .
```
```
go: github.com/btcsuite/btcd@v0.20.1-beta: Get https://proxy.golang.org/github.com/btcsuite/btcd/@v/v0.20.1-beta.mod: dial tcp: lookup proxy.golang.org on 
 i/o timeout
make: *** [Makefile:139: build] Error 1
```
This can be made configurable depending on operator needs. This is just a suggestion to unblock folks using Docker environments.

