### PR TITLE
eliminate genblocks compile warning

### DIFF
--- a/testtools/genblocks/main.go
+++ b/testtools/genblocks/main.go
@@ -88,7 +88,7 @@ func main() {
 				" maximum 65535"))
 		}
 
-		hashOfTxnsAndHeight := sha256.Sum256([]byte(allTransactionsHex + "#" + string(curHeight)))
+		hashOfTxnsAndHeight := sha256.Sum256([]byte(allTransactionsHex + "#" + string(rune(curHeight))))
 
 		// These fields do not need to be valid for the lightwalletd/wallet stack to work.
 		// The lightwalletd/wallet stack rely on the miners to validate these.


### PR DESCRIPTION
```
testtools/genblocks/main.go:91:74: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
```
See https://github.com/golang/go/issues/32479

This problem is the result of a recent go compiler update (for example 1.16.2), and it's only a warning.