### PR TITLE
Get latest block from zcashd

### DIFF
--- a/frontend/service.go
+++ b/frontend/service.go
@@ -57,14 +57,18 @@ func checkTaddress(taddr string) error {
 
 // GetLatestBlock returns the height of the best chain, according to zcashd.
 func (s *lwdStreamer) GetLatestBlock(ctx context.Context, placeholder *walletrpc.ChainSpec) (*walletrpc.BlockID, error) {
-	latestBlock := s.cache.GetLatestHeight()
-
-	if latestBlock == -1 {
-		return nil, errors.New("Cache is empty. Server is probably not yet ready")
+	result, rpcErr := common.RawRequest("getblockchaininfo", []json.RawMessage{})
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+	var getblockchaininfoReply common.ZcashdRpcReplyGetblockchaininfo
+	err := json.Unmarshal(result, &getblockchaininfoReply)
+	if err != nil {
+		return nil, rpcErr
 	}
 
 	// TODO: also return block hashes here
-	return &walletrpc.BlockID{Height: uint64(latestBlock)}, nil
+	return &walletrpc.BlockID{Height: uint64(getblockchaininfoReply.Blocks)}, nil
 }
 
 // GetTaddressTxids is a streaming RPC that returns transaction IDs that have


### PR DESCRIPTION
I propose that we get the latest block from `zcashd` instead of from the cache. 

This fixes an issue where in some rare cases, the value returned from `GetLightDInfo` doesn't match what `GetLatestBlock` returns if the cache is slightly behind. 

Also, If the cache is behind or if the server is just starting, we should ask zcashd for the latest block height, because when the clients request for a block and we don't have it, we go to `zcashd`  anyway.