### PR TITLE
Return hashes from getlatestblock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ lwd-api.html
 *.orig
 __debug_bin
 .vscode
+frontend/unittestcache/

--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -191,6 +191,9 @@ func TestGetLatestBlock(t *testing.T) {
 	if blockID.Height != 380640 {
 		t.Fatal("unexpected blockID.height")
 	}
+	if string(blockID.Hash) != string(block.Hash) {
+		t.Fatal("unexpected blockID.hash")
+	}
 	step = 0
 }
 

--- a/frontend/service.go
+++ b/frontend/service.go
@@ -58,13 +58,13 @@ func checkTaddress(taddr string) error {
 // GetLatestBlock returns the height of the best chain, according to zcashd.
 func (s *lwdStreamer) GetLatestBlock(ctx context.Context, placeholder *walletrpc.ChainSpec) (*walletrpc.BlockID, error) {
 	latestBlock := s.cache.GetLatestHeight()
+	latestHash := s.cache.GetLatestHash()
 
 	if latestBlock == -1 {
 		return nil, errors.New("Cache is empty. Server is probably not yet ready")
 	}
 
-	// TODO: also return block hashes here
-	return &walletrpc.BlockID{Height: uint64(latestBlock)}, nil
+	return &walletrpc.BlockID{Height: uint64(latestBlock), Hash: latestHash}, nil
 }
 
 // GetTaddressTxids is a streaming RPC that returns transaction IDs that have


### PR DESCRIPTION
Return the Hash (along with the Height) for the `getLatestBlock` RPC