### PR TITLE
improve reorg by using getbestblockhash

### DIFF
--- a/common/cache.go
+++ b/common/cache.go
@@ -51,12 +51,12 @@ func (c *BlockCache) GetLatestHash() []byte {
 	return c.latestHash
 }
 
-// HashMismatch indicates if the given prev-hash doesn't match the most recent block's hash
+// HashMatch indicates if the given prev-hash matches the most recent block's hash
 // so reorgs can be detected.
-func (c *BlockCache) HashMismatch(prevhash []byte) bool {
+func (c *BlockCache) HashMatch(prevhash []byte) bool {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
-	return c.latestHash != nil && !bytes.Equal(c.latestHash, prevhash)
+	return c.latestHash == nil || bytes.Equal(c.latestHash, prevhash)
 }
 
 // Make the block at the given height the lowest height that we don't have.

--- a/common/darkside.go
+++ b/common/darkside.go
@@ -77,7 +77,7 @@ func DarksideInit(c *BlockCache, timeout int) {
 // DarksideReset allows the wallet test code to specify values
 // that are returned by GetLightdInfo().
 func DarksideReset(sa int, bi, cn string) error {
-	Log.Info("Reset(saplingActivation=", sa, ")")
+	Log.Info("DarksideReset(saplingActivation=", sa, ")")
 	stopIngestor()
 	state = darksideState{
 		resetted:             true,
@@ -138,7 +138,7 @@ func setPrevhash() {
 			copy(blockBytes[4:4+32], prevhash)
 		}
 		prevhash = block.GetEncodableHash()
-		Log.Info("active block height ", block.GetHeight(), " hash ",
+		Log.Info("Darkside active block height ", block.GetHeight(), " hash ",
 			hex.EncodeToString(block.GetDisplayHash()),
 			" txcount ", block.GetTxCount())
 	}
@@ -153,7 +153,7 @@ func DarksideApplyStaged(height int) error {
 	if !state.resetted {
 		return errors.New("please call Reset first")
 	}
-	Log.Info("ApplyStaged(height=", height, ")")
+	Log.Info("DarksideApplyStaged(height=", height, ")")
 	if height < state.startHeight {
 		return errors.New(fmt.Sprint("height ", height,
 			" is less than sapling activation height ", state.startHeight))
@@ -212,9 +212,13 @@ func DarksideApplyStaged(height int) error {
 		block = append(block, tx.bytes...)
 		state.activeBlocks[tx.height-state.startHeight] = block
 	}
+	maxHeight := state.startHeight + len(state.activeBlocks) - 1
+	if height > maxHeight {
+		height = maxHeight
+	}
 	setPrevhash()
 	state.latestHeight = height
-	Log.Info("active blocks from ", state.startHeight,
+	Log.Info("darkside: active blocks from ", state.startHeight,
 		" to ", state.startHeight+len(state.activeBlocks)-1,
 		", latest presented height ", state.latestHeight)
 
@@ -244,7 +248,7 @@ func darksideStageBlock(caller string, b []byte) error {
 	if len(rest) != 0 {
 		return errors.New("block serialization is too long")
 	}
-	Log.Info(caller, "(height=", block.GetHeight(), ")")
+	Log.Info(caller, "DarksideStageBlock(height=", block.GetHeight(), ")")
 	if block.GetHeight() < state.startHeight {
 		return errors.New(fmt.Sprint("block height ", block.GetHeight(),
 			" is less than sapling activation height ", state.startHeight))
@@ -259,7 +263,7 @@ func DarksideStageBlocks(url string) error {
 	if !state.resetted {
 		return errors.New("please call Reset first")
 	}
-	Log.Info("StageBlocks(url=", url, ")")
+	Log.Info("DarksideStageBlocks(url=", url, ")")
 	resp, err := http.Get(url)
 	if err != nil {
 		return err
@@ -292,7 +296,7 @@ func DarksideStageBlockStream(blockHex string) error {
 	if !state.resetted {
 		return errors.New("please call Reset first")
 	}
-	Log.Info("StageBlocksStream()")
+	Log.Info("DarksideStageBlocksStream()")
 	blockBytes, err := hex.DecodeString(blockHex)
 	if err != nil {
 		return err
@@ -308,7 +312,7 @@ func DarksideStageBlocksCreate(height int32, nonce int32, count int32) error {
 	if !state.resetted {
 		return errors.New("please call Reset first")
 	}
-	Log.Info("StageBlocksCreate(height=", height, ", nonce=", nonce, ", count=", count, ")")
+	Log.Info("DarksideStageBlocksCreate(height=", height, ", nonce=", nonce, ", count=", count, ")")
 	for i := 0; i < int(count); i++ {
 
 		fakeCoinbase := "0400008085202f890100000000000000000000000000000000000000000000000000" +
@@ -412,6 +416,18 @@ func darksideRawRequest(method string, params []json.RawMessage) (json.RawMessag
 			return nil, errors.New(notFoundErr)
 		}
 		return json.Marshal(hex.EncodeToString(state.activeBlocks[index]))
+
+	case "getbestblockhash":
+		state.mutex.RLock()
+		defer state.mutex.RUnlock()
+		if len(state.activeBlocks) == 0 {
+			Log.Fatal("getbestblockhash: no blocks")
+		}
+		index := state.latestHeight - state.startHeight
+		block := parser.NewBlock()
+		block.ParseFromSlice(state.activeBlocks[index])
+		hash := hex.EncodeToString(block.GetDisplayHash())
+		return json.Marshal(hash)
 
 	case "getaddresstxids":
 		// Not required for minimal reorg testing.
@@ -577,7 +593,7 @@ func DarksideStageTransactionsURL(height int, url string) error {
 	if !state.resetted {
 		return errors.New("please call Reset first")
 	}
-	Log.Info("StageTransactionsURL(height=", height, ", url=", url, ")")
+	Log.Info("DarksideStageTransactionsURL(height=", height, ", url=", url, ")")
 	resp, err := http.Get(url)
 	if err != nil {
 		return err

--- a/docs/darksidewalletd.md
+++ b/docs/darksidewalletd.md
@@ -94,6 +94,16 @@ block height to another. This happens in two parts, first we create and apply
 the "before reorg" state. Then we create the "after reorg" stage and apply
 it, which makes the reorg happen.
 
+Here's a quick-start guide to simulating a reorg:
+```
+grpcurl -plaintext -d '{"saplingActivation": 663150,"branchID": "bad", "chainName":"x"}' localhost:9067 cash.z.wallet.sdk.rpc.DarksideStreamer/Reset
+grpcurl -plaintext -d '{"url": "https://raw.githubusercontent.com/zcash-hackworks/darksidewalletd-test-data/master/basic-reorg/663150.txt"}' localhost:9067 cash.z.wallet.sdk.rpc.DarksideStreamer/StageBlocks
+grpcurl -plaintext -d '{"height":663151,"count":10}' localhost:9067 cash.z.wallet.sdk.rpc.DarksideStreamer/StageBlocksCreate
+grpcurl -plaintext -d '{"height":663160}' localhost:9067 cash.z.wallet.sdk.rpc.DarksideStreamer/ApplyStaged
+grpcurl -plaintext -d '{"height":663155,"count":10,"nonce":44}' localhost:9067 cash.z.wallet.sdk.rpc.DarksideStreamer/StageBlocksCreate
+grpcurl -plaintext -d '{"height":663164}' localhost:9067 cash.z.wallet.sdk.rpc.DarksideStreamer/ApplyStaged
+```
+
 #### Creating the Before-Reorg State
 
 If you haven't already started darksidewalletd, please start it:


### PR DESCRIPTION
This is the implementation of the suggestion here: https://github.com/zcash/lightwalletd/pull/348#issuecomment-882876624. This should make that PR unnecessary (since the latest block height won't jump around). This new version also has the virtue of being simpler.

@adityapk00 and @nighthawk24, perhaps you can review and test these changes.

CC @pacu @defuse 