### PR TITLE
performance: don't deserialize unused tx fields

### DIFF
--- a/parser/internal/bytestring/bytestring.go
+++ b/parser/internal/bytestring/bytestring.go
@@ -137,6 +137,11 @@ func (s *String) ReadCompactSize(size *int) bool {
 	return true
 }
 
+func (s *String) SkipCompactSize() bool {
+	var unused int
+	return s.ReadCompactSize(&unused)
+}
+
 // ReadCompactLengthPrefixed reads data prefixed by a CompactSize-encoded
 // length field into out. It reports whether the read was successful.
 func (s *String) ReadCompactLengthPrefixed(out *String) bool {
@@ -152,6 +157,16 @@ func (s *String) ReadCompactLengthPrefixed(out *String) bool {
 
 	*out = v
 	return true
+}
+
+// SkipCompactLengthPrefixed reads a CompactSize-encoded
+// length field, then skips that many bytes.
+func (s *String) SkipCompactLengthPrefixed() bool {
+	var length int
+	if !s.ReadCompactSize(&length) {
+		return false
+	}
+	return s.Skip(length)
 }
 
 // ReadInt32 decodes a little-endian 32-bit value into out, treating it as

--- a/parser/internal/bytestring/bytestring_test.go
+++ b/parser/internal/bytestring/bytestring_test.go
@@ -261,6 +261,38 @@ func TestString_ReadCompactLengthPrefixed(t *testing.T) {
 	}
 }
 
+func TestString_SkipCompactLengthPrefixed(t *testing.T) {
+	// a stream of 3 bytes followed by 2 bytes into the value variable, v
+	s := String{3, 55, 66, 77, 2, 88, 99}
+
+	// read the 3 and thus the following 3 bytes
+	if !s.SkipCompactLengthPrefixed() {
+		t.Fatalf("SkipCompactLengthPrefix failed")
+	}
+	if len(s) != 3 {
+		t.Fatalf("SkipCompactLengthPrefix incorrect remaining length")
+	}
+
+	// read the 2 and then two bytes
+	if !s.SkipCompactLengthPrefixed() {
+		t.Fatalf("SkipCompactLengthPrefix failed")
+	}
+	if len(s) != 0 {
+		t.Fatalf("SkipCompactLengthPrefix incorrect remaining length")
+	}
+
+	// at the end of the String, another read should return false
+	if s.SkipCompactLengthPrefixed() {
+		t.Fatalf("SkipCompactLengthPrefix unexpected success")
+	}
+
+	// this string is too short (less than 2 bytes of data)
+	s = String{3, 55, 66}
+	if s.SkipCompactLengthPrefixed() {
+		t.Fatalf("SkipdCompactLengthPrefix unexpected success")
+	}
+}
+
 var readInt32Tests = []struct {
 	s        String
 	expected int32


### PR DESCRIPTION
Non-functional change, don't bother to deserialize data that are never used, skip instead; this change slightly reduces both CPU and memory usage.