### PR TITLE
compact blocks should include Orchard transactions

### DIFF
--- a/parser/block.go
+++ b/parser/block.go
@@ -62,7 +62,7 @@ func (b *Block) GetDisplayPrevHash() []byte {
 // HasSaplingTransactions indicates if the block contains any Sapling tx.
 func (b *Block) HasSaplingTransactions() bool {
 	for _, tx := range b.vtx {
-		if tx.HasSaplingElements() {
+		if tx.HasShieldedElements() {
 			return true
 		}
 	}
@@ -118,7 +118,7 @@ func (b *Block) ToCompact() *walletrpc.CompactBlock {
 	// Only Sapling transactions have a meaningful compact encoding
 	saplingTxns := make([]*walletrpc.CompactTx, 0, len(b.vtx))
 	for idx, tx := range b.vtx {
-		if tx.HasSaplingElements() {
+		if tx.HasShieldedElements() {
 			saplingTxns = append(saplingTxns, tx.ToCompact(idx))
 		}
 	}

--- a/parser/transaction.go
+++ b/parser/transaction.go
@@ -369,10 +369,11 @@ func (tx *Transaction) Bytes() []byte {
 	return tx.rawBytes
 }
 
-// HasSaplingElements indicates whether a transaction has
+// HasShieldedElements indicates whether a transaction has
 // at least one shielded input or output.
-func (tx *Transaction) HasSaplingElements() bool {
-	return tx.version >= 4 && (len(tx.shieldedSpends)+len(tx.shieldedOutputs)) > 0
+func (tx *Transaction) HasShieldedElements() bool {
+	nshielded := len(tx.shieldedSpends) + len(tx.shieldedOutputs) + len(tx.orchardActions)
+	return tx.version >= 4 && nshielded > 0
 }
 
 // ToCompact converts the given (full) transaction to compact format.


### PR DESCRIPTION
In the previous commit, I forgot to include Orchard transactions in compact blocks (so they will now include transactions with either Sapling or Orchard transactions).