### PR TITLE
add --sync-from-height command-line option

### DIFF
--- a/common/cache_test.go
+++ b/common/cache_test.go
@@ -58,7 +58,7 @@ func TestCache(t *testing.T) {
 
 	// Pretend Sapling starts at 289460.
 	os.RemoveAll(unitTestPath)
-	cache = NewBlockCache(unitTestPath, unitTestChain, 289460, true)
+	cache = NewBlockCache(unitTestPath, unitTestChain, 289460, 0)
 
 	// Initially cache is empty.
 	if cache.GetLatestHeight() != -1 {
@@ -75,7 +75,7 @@ func TestCache(t *testing.T) {
 	fillCache(t)
 
 	// Simulate a restart to ensure the db files are read correctly.
-	cache = NewBlockCache(unitTestPath, unitTestChain, 289460, false)
+	cache = NewBlockCache(unitTestPath, unitTestChain, 289460, -1)
 
 	// Should still be 6 blocks.
 	if cache.nextBlock != 289466 {

--- a/common/common.go
+++ b/common/common.go
@@ -42,6 +42,7 @@ type Options struct {
 	NoTLSVeryInsecure   bool   `json:"no_tls_very_insecure,omitempty"`
 	GenCertVeryInsecure bool   `json:"gen_cert_very_insecure,omitempty"`
 	Redownload          bool   `json:"redownload"`
+	SyncFromHeight      int    `json:"sync_from_height"`
 	DataDir             string `json:"data_dir"`
 	PingEnable          bool   `json:"ping_enable"`
 	Darkside            bool   `json:"darkside"`

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -62,7 +62,7 @@ func TestMain(m *testing.M) {
 		blockJSON, _ := json.Marshal(scan.Text())
 		blocks = append(blocks, blockJSON)
 	}
-	testcache = NewBlockCache(unitTestPath, unitTestChain, 380640, true)
+	testcache = NewBlockCache(unitTestPath, unitTestChain, 380640, 0)
 
 	// Setup is done; run all tests.
 	exitcode := m.Run()
@@ -355,7 +355,7 @@ func TestBlockIngestor(t *testing.T) {
 	Time.Sleep = sleepStub
 	Time.Now = nowStub
 	os.RemoveAll(unitTestPath)
-	testcache = NewBlockCache(unitTestPath, unitTestChain, 380640, false)
+	testcache = NewBlockCache(unitTestPath, unitTestChain, 380640, -1)
 	BlockIngestor(testcache, 11)
 	if step != 19 {
 		t.Error("unexpected final step", step)
@@ -488,7 +488,7 @@ func TestGetBlockRange(t *testing.T) {
 	testT = t
 	RawRequest = getblockStub
 	os.RemoveAll(unitTestPath)
-	testcache = NewBlockCache(unitTestPath, unitTestChain, 380640, true)
+	testcache = NewBlockCache(unitTestPath, unitTestChain, 380640, 0)
 	blockChan := make(chan *walletrpc.CompactBlock)
 	errChan := make(chan error)
 	go GetBlockRange(testcache, blockChan, errChan, 380640, 380642)
@@ -567,7 +567,7 @@ func TestGetBlockRangeReverse(t *testing.T) {
 	testT = t
 	RawRequest = getblockStubReverse
 	os.RemoveAll(unitTestPath)
-	testcache = NewBlockCache(unitTestPath, unitTestChain, 380640, true)
+	testcache = NewBlockCache(unitTestPath, unitTestChain, 380640, 0)
 	blockChan := make(chan *walletrpc.CompactBlock)
 	errChan := make(chan error)
 

--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -36,7 +36,7 @@ const (
 
 func testsetup() (walletrpc.CompactTxStreamerServer, *common.BlockCache) {
 	os.RemoveAll(unitTestPath)
-	cache := common.NewBlockCache(unitTestPath, unitTestChain, 380640, true)
+	cache := common.NewBlockCache(unitTestPath, unitTestChain, 380640, 0)
 	lwd, err := NewLwdStreamer(cache, "main", false /* enablePing */)
 	if err != nil {
 		os.Stderr.WriteString(fmt.Sprint("NewLwdStreamer failed:", err))


### PR DESCRIPTION
This causes lightwalletd to discard cached blocks at the given height
and beyond. This in turn causes it to re-fetch those blocks from zcashd.
It's similar to --redownload, except that option discards all blocks
(equivalent to --sync-from-height 0, but the existing --redownload is
retained for compatibility).

This is mostly intended for testing. It's sometimes useful to force the
node to (re)sync some recent blocks, but redownloading all of them takes
around an hour.
