### PR TITLE
improve the getblock error message

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -369,7 +369,7 @@ func BlockIngestor(c *BlockCache, rep int) {
 		var block *walletrpc.CompactBlock
 		block, err = getBlockFromRPC(height)
 		if err != nil {
-			Log.Fatal("getblock failed, will retry", err)
+			Log.Fatal("getblock ", height, " failed, will retry: ", err)
 		}
 		if block != nil && c.HashMatch(block.PrevHash) {
 			if err = c.Add(height, block); err != nil {


### PR DESCRIPTION
in production (on testnet), we're getting errors that look like:
```
{"app":"lightwalletd","level":"fatal","msg":"getblock failed, will retryerror parsing block: parsing transaction 0: unknown consensusBranchID","time":"2022-04-26T02:53:43Z"}
```
and it would help a lot to have an idea *which block* lightwalletd is trying to fetch. 