### PR TITLE
[#388] Darksidewalletd does not tell developers why it failed

### DIFF
--- a/common/darkside.go
+++ b/common/darkside.go
@@ -496,7 +496,7 @@ func darksideRawRequest(method string, params []json.RawMessage) (json.RawMessag
 		return json.Marshal(utxosReply)
 
 	default:
-		return nil, errors.New("there was an attempt to call an unsupported RPC")
+		return nil, errors.New("there was an attempt to call an unsupported RPC: " + method)
 	}
 }
 


### PR DESCRIPTION
Darksidewalletd does not tell developers why it failed when a method is invoked

closes #388 

Please ensure this checklist is followed for any pull requests for this repo. This checklist must be checked by both the PR creator and by anyone who reviews the PR.

As a note, all CI tests need to be passing and all appropriate code reviews need to be done before this PR can be merged
