### PR TITLE
eliminate redundancy, point URL to zingolabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ limitations of light wallets that use lightwalletd.
 
 # Overview
 
-[lightwalletd](https://github.com/zcash/lightwalletd) is a backend service that provides a bandwidth-efficient interface to the Zcash blockchain. Currently, lightwalletd supports the Sapling protocol version and beyond as its primary concern. The intended purpose of lightwalletd is to support the development and operation of mobile-friendly shielded light wallets.
+[lightwalletd](https://github.com/zcash/lightwalletd) is a backend service that provides a bandwidth-efficient interface to the Zcash blockchain for mobile and other wallets, such as [Zecwallet](https://github.com/zingolabs/zecwalletlitelib).
 
-lightwalletd is a backend service that provides a bandwidth-efficient interface to the Zcash blockchain for mobile and other wallets, such as [Zecwallet](https://github.com/adityapk00/zecwallet-lite-lib).
+Currently, lightwalletd supports the Sapling protocol version and beyond as its primary concern. The intended purpose of lightwalletd is to support the development and operation of mobile-friendly shielded light wallets.
 
 To view status of [CI pipeline](https://gitlab.com/zcash/lightwalletd/pipelines)
 


### PR DESCRIPTION
I found some redundancy in the readme which I removed, and I have pointed the linking URL to our own `zecwalletlitelib` repo.