### PR TITLE
Fix GetMempoolTx bug returning no entries

### DIFF
--- a/common/mempool.go
+++ b/common/mempool.go
@@ -54,7 +54,6 @@ func GetMempool(sendToClient func(*walletrpc.RawTransaction) error) error {
 			if g_lastBlockChainInfo.BestBlockHash != blockChainInfo.BestBlockHash {
 				// A new block has arrived
 				g_lastBlockChainInfo = blockChainInfo
-				Log.Infoln("Latest Block changed, clearing everything")
 				// We're the first thread to notice, clear cached state.
 				g_txidSeen = map[txid]struct{}{}
 				g_txList = []*walletrpc.RawTransaction{}
@@ -89,8 +88,6 @@ func GetMempool(sendToClient func(*walletrpc.RawTransaction) error) error {
 
 // RefreshMempoolTxns gets all new mempool txns and sends any new ones to waiting clients
 func refreshMempoolTxns() error {
-	Log.Infoln("Refreshing mempool")
-
 	params := []json.RawMessage{}
 	result, rpcErr := RawRequest("getrawmempool", params)
 	if rpcErr != nil {
@@ -132,7 +129,6 @@ func refreshMempoolTxns() error {
 		if err != nil {
 			return err
 		}
-		Log.Infoln("appending", txidstr)
 		newRtx := &walletrpc.RawTransaction{
 			Data:   txBytes,
 			Height: uint64(g_lastBlockChainInfo.Blocks),

--- a/frontend/service.go
+++ b/frontend/service.go
@@ -466,6 +466,11 @@ func (s *lwdStreamer) GetMempoolTx(exclude *walletrpc.Exclude, resp walletrpc.Co
 			}
 			newmempoolMap[txidstr] = &walletrpc.CompactTx{}
 			if tx.HasShieldedElements() {
+				txidBytes, err := hex.DecodeString(txidstr)
+				if err != nil {
+					return err
+				}
+				tx.SetTxID(txidBytes)
 				newmempoolMap[txidstr] = tx.ToCompact( /* height */ 0)
 			}
 		}


### PR DESCRIPTION
This was broken by PR #393, which changed how txids are determined. After `GetMempoolTx` fetches individual transactions, they're converted to compact format, one attribute of which is transaction ID (txid), and that wasn't being filled in. This prevented any entries from being returned (see test at https://github.com/zcash/lightwalletd/blob/db2795aad7043fb226bbf579aee29633583990ef/frontend/service.go#L480)

Note that this gRPC is probably not being widely used; the ECC wallets use the more recent (and arguably superior) `GetMempoolStream`.