### PR TITLE
Fix reorg race condition that can cause rare crashes

### DIFF
--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -136,23 +136,29 @@ func TestGetTransaction(t *testing.T) {
 }
 
 func getblockStub(method string, params []json.RawMessage) (json.RawMessage, error) {
+	if method != "getblock" {
+		testT.Fatal("unexpected method:", method)
+	}
 	step++
-	var height string
-	err := json.Unmarshal(params[0], &height)
+	var arg string
+	err := json.Unmarshal(params[0], &arg)
 	if err != nil {
 		testT.Fatal("could not unmarshal height")
-	}
-	if height != "380640" {
-		testT.Fatal("unexpected getblock height", height)
 	}
 
 	// Test retry logic (for the moment, it's very simple, just one retry).
 	switch step {
 	case 1:
-		return blocks[0], nil
-	case 2:
+		if arg != "380640" {
+			testT.Fatal("unexpected getblock height", arg)
+		}
 		// verbose mode (getblock height 1), return transaction list
-		return []byte("{\"Tx\": [\"00\"]}"), nil
+		return []byte("{\"Tx\": [\"00\"], \"Hash\": \"0000380640\"}"), nil
+	case 2:
+		if arg != "0000380640" {
+			testT.Fatal("unexpected getblock height", arg)
+		}
+		return blocks[0], nil
 	case 3:
 		return nil, errors.New("getblock test error, too many requests")
 	}


### PR DESCRIPTION
Fixes issue #408.

This bug was introduced by PR #393, which changed how txids are
determined. That PR changed each call to the zcash getblock call into a
pair of calls, the first to get the raw block data, the second to
retrieve the txids in the block. (Unfortunately, you can't get both in a
single getblock RPC.) But this ordering introduced a timing window in
which the block at the given height can change, if a reorg occurred
between the two calls.

This PR reorders the getblock calls, so that the first call gets the
transaction IDs, which also happens to return the block hash, so then
the second getblock call can specify the block hash, rather than the
height. This ensures that the two RPC calls return consistent data,
definitely the same block.