### PR TITLE
Fix darksidewallet for tx v5 (txid) changes

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -418,7 +418,10 @@ func GetBlock(cache *BlockCache, height int) (*walletrpc.CompactBlock, error) {
 		return block, nil
 	}
 
-	// Not in the cache, ask zcashd
+	// Not in the cache
+	if DarksideEnabled {
+		return nil, errors.New("block not found in cache, should always be in cache in darkside mode")
+	}
 	block, err := getBlockFromRPC(height)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Darkside test framework broke due to the V5 txid changes (issue 392).
This change enhances darksideRawRequest("getblock") to allow the
argument to be either a height or a block hash, rather than only a
height.

Closes #345

@pacu I'm adding you as reviewer but all I'd like for you to do is test this branch before I merge to master.

@steven-ecc I added you as reviewer, but optional.