### PR TITLE
Add spam filters

### DIFF
--- a/common/common_test.go
+++ b/common/common_test.go
@@ -411,7 +411,7 @@ func TestGetBlockRange(t *testing.T) {
 	testcache = NewBlockCache(unitTestPath, unitTestChain, 380640, 0)
 	blockChan := make(chan *walletrpc.CompactBlock)
 	errChan := make(chan error)
-	go GetBlockRange(testcache, blockChan, errChan, 380640, 380642)
+	go GetBlockRange(testcache, blockChan, errChan, 380640, 380642, 0)
 
 	// read in block 380640
 	select {
@@ -510,7 +510,7 @@ func TestGetBlockRangeReverse(t *testing.T) {
 	errChan := make(chan error)
 
 	// Request the blocks in reverse order by specifying start greater than end
-	go GetBlockRange(testcache, blockChan, errChan, 380642, 380640)
+	go GetBlockRange(testcache, blockChan, errChan, 380642, 380640, 0)
 
 	// read in block 380642
 	select {

--- a/frontend/service.go
+++ b/frontend/service.go
@@ -160,7 +160,7 @@ func (s *lwdStreamer) GetBlockRange(span *walletrpc.BlockRange, resp walletrpc.C
 		return errors.New("must specify start and end heights")
 	}
 	errChan := make(chan error)
-	go common.GetBlockRange(s.cache, blockChan, errChan, int(span.Start.Height), int(span.End.Height))
+	go common.GetBlockRange(s.cache, blockChan, errChan, int(span.Start.Height), int(span.End.Height), int(span.SpamFilterThreshold))
 
 	for {
 		select {

--- a/walletrpc/service.pb.go
+++ b/walletrpc/service.pb.go
@@ -88,8 +88,9 @@ type BlockRange struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Start *BlockID `protobuf:"bytes,1,opt,name=start,proto3" json:"start,omitempty"`
-	End   *BlockID `protobuf:"bytes,2,opt,name=end,proto3" json:"end,omitempty"`
+	Start               *BlockID `protobuf:"bytes,1,opt,name=start,proto3" json:"start,omitempty"`
+	End                 *BlockID `protobuf:"bytes,2,opt,name=end,proto3" json:"end,omitempty"`
+	SpamFilterThreshold uint64   `protobuf:"varint,3,opt,name=spamFilterThreshold,proto3" json:"spamFilterThreshold,omitempty"`
 }
 
 func (x *BlockRange) Reset() {
@@ -136,6 +137,13 @@ func (x *BlockRange) GetEnd() *BlockID {
 		return x.End
 	}
 	return nil
+}
+
+func (x *BlockRange) GetSpamFilterThreshold() uint64 {
+	if x != nil {
+		return x.SpamFilterThreshold
+	}
+	return 0
 }
 
 // A TxFilter contains the information needed to identify a particular

--- a/walletrpc/service.proto
+++ b/walletrpc/service.proto
@@ -20,6 +20,7 @@ message BlockID {
 message BlockRange {
     BlockID start = 1;
     BlockID end = 2;
+    uint64 spamFilterThreshold = 3;
 }
 
 // A TxFilter contains the information needed to identify a particular


### PR DESCRIPTION
Add the ability to filter (modify) spammy transactions in the compact blocks returned by the `GetBlockRange()` gRPC, based on its new `spamFilterThreshold` argument. The filtering consists of removing (setting to an empty bytes array) the following fields from transactions whose number-of-sapling-outputs plus number-of-orchard-actions exceeds the threshold:

- Sapling `Outputs`:
  - `Ciphertext`
  - `Epk`
- Orchard `Actions`:
  - `Ciphertext`
  - `EphemeralKey`
  - `Nullifier`

The default is to not filter at all (so this change is backward compatible).