### PR TITLE
fix GetLatestBlock() gRPC (pure block cache)

### DIFF
--- a/common/mempool.go
+++ b/common/mempool.go
@@ -46,7 +46,7 @@ func GetMempool(sendToClient func(*walletrpc.RawTransaction) error) error {
 		// Don't fetch the mempool more often than every 2 seconds.
 		now := Time.Now()
 		if now.After(g_lastTime.Add(2 * time.Second)) {
-			blockChainInfo, err := getLatestBlockChainInfo()
+			blockChainInfo, err := GetBlockChainInfo()
 			if err != nil {
 				g_lock.Unlock()
 				return err
@@ -136,17 +136,4 @@ func refreshMempoolTxns() error {
 		g_txList = append(g_txList, newRtx)
 	}
 	return nil
-}
-
-func getLatestBlockChainInfo() (*ZcashdRpcReplyGetblockchaininfo, error) {
-	result, rpcErr := RawRequest("getblockchaininfo", []json.RawMessage{})
-	if rpcErr != nil {
-		return nil, rpcErr
-	}
-	var getblockchaininfoReply ZcashdRpcReplyGetblockchaininfo
-	err := json.Unmarshal(result, &getblockchaininfoReply)
-	if err != nil {
-		return nil, err
-	}
-	return &getblockchaininfoReply, nil
 }


### PR DESCRIPTION
Fixes #397. If the block cache is still populating (lightwalletd is syncing with zcashd), behave the same as if the cache was fully populated, other than performance.

This turned out to affect only the GetLatestBlock() gRPC. Previously, it would return the height and hash of the latest block in the cache. After this commit, it queries zcashd using the getblockchaininfo, which contains both of those values.

The only possible downside to this change is if the client calls `GetLatestBlock()` very frequently; with this change, each call requires an RPC to `zcashd`. But even a frequency of, say, once per second would be completely fine, and there's no reason it would be called more frequently than that (general range).

GetBlock() (and GetBlockRange()) already worked correctly; if the requested block isn't in the cache, it requests it from zcashd.
