### PR TITLE
darkside: fix GetBlock intermittent (timing) failure

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -427,9 +427,6 @@ func GetBlock(cache *BlockCache, height int) (*walletrpc.CompactBlock, error) {
 	}
 
 	// Not in the cache
-	if DarksideEnabled {
-		return nil, errors.New("block not found in cache, should always be in cache in darkside mode")
-	}
 	block, err := getBlockFromRPC(height)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In PR 412 (darksidewallet fixes for tx v5), I added a failure condition to the GetBlock gRPC based on a block being requested always being in the cache. I believe my thinking was that since there is no asynchronous independent zcashd, if it wasn't in the cache, it never would be. I failed to take into account that the block ingestor takes time to run, and a test can run quickly enough that the block ingestor hasn't had time to process the block. I reproduced the problem by commenting out the starting of the block ingestor.

I think that error condition can be removed, which is what this commit does. I tested by leaving the block ingestor commented out, so that GetBlock has to use the RPC interface to get the block, and it works.