### PR TITLE
extend darksidewallet locking

### DIFF
--- a/frontend/service.go
+++ b/frontend/service.go
@@ -335,6 +335,7 @@ func (s *lwdStreamer) SendTransaction(ctx context.Context, rawtx *walletrpc.RawT
 			return nil, errors.New("sendTransaction couldn't parse error code")
 		}
 	} else {
+		// Return the transaction ID (txid) as hex string.
 		errMsg = string(result)
 	}
 


### PR DESCRIPTION
Closes #433. This is a test-only bug-fix. See #433 for a detailed analysis. This PR tightens up the locking, moving the mutex out of the `state` structure so that `Reset()` doesn't re-create the mutex. That mutex should never be recreated (if it is, it's difficult to know that there aren't any locking bugs).