### PR TITLE
improve startup logging (no functional change)

### DIFF
--- a/common/cache.go
+++ b/common/cache.go
@@ -228,7 +228,9 @@ func NewBlockCache(dbPath string, chainName string, startHeight int, syncFromHei
 	var offset int64
 	c.starts = nil
 	c.starts = append(c.starts, 0)
-	for i := 0; i < len(lengths)/4; i++ {
+	nBlocks := len(lengths) / 4
+	Log.Info("Reading ", nBlocks, " blocks (since Sapling activation) from disk cache ...")
+	for i := 0; i < nBlocks; i++ {
 		if len(lengths[:4]) < 4 {
 			Log.Warning("lengths file has a partial entry")
 			c.recoverFromCorruption(c.nextBlock)
@@ -252,7 +254,7 @@ func NewBlockCache(dbPath string, chainName string, startHeight int, syncFromHei
 		c.nextBlock++
 	}
 	c.setDbFiles(c.nextBlock)
-	Log.Info("Found ", c.nextBlock-c.firstBlock, " blocks in cache")
+	Log.Info("Done reading ", c.nextBlock-c.firstBlock, " blocks from disk cache")
 	return c
 }
 


### PR DESCRIPTION
When `lightwalletd` starts up, it logs a few messages, ending in:
```
Got sapling height 419200 block height 2111377 chain main branchID c2d6d0b4
```
There ensues a one or 2 minute delay (depending on the hardware being used) while the process reads all the compact blocks from the disk cache. To anyone watching the logs to see when the server is fully up and running, it's unclear what's going on.

This PR adds logging to inform the user, for example:
```
Got sapling height 419200 block height 2111377 chain main branchID c2d6d0b4
Reading 1692195 blocks (since Sapling activation) from disk cache ...
[ ... delay ... ]
Done reading 1692195 blocks from disk cache
```