### PR TITLE
Only pass `limit` argument to `z_getsubtreesbyindex` if `maxEntries > 0`

### DIFF
--- a/frontend/service.go
+++ b/frontend/service.go
@@ -689,14 +689,16 @@ func (s *lwdStreamer) GetSubtreeRoots(arg *walletrpc.GetSubtreeRootsArg, resp wa
 	if err != nil {
 		return errors.New("bad startIndex")
 	}
-	maxEntriesJSON, err := json.Marshal(arg.MaxEntries)
-	if err != nil {
-		return errors.New("bad maxEntries")
-	}
 	params := []json.RawMessage{
 		protocol,
 		startIndexJSON,
-		maxEntriesJSON,
+	}
+	if arg.MaxEntries > 0 {
+		maxEntriesJSON, err := json.Marshal(arg.MaxEntries)
+		if err != nil {
+			return errors.New("bad maxEntries")
+		}
+		params = append(params, maxEntriesJSON)
 	}
 	result, rpcErr := common.RawRequest("z_getsubtreesbyindex", params)
 
@@ -708,7 +710,7 @@ func (s *lwdStreamer) GetSubtreeRoots(arg *walletrpc.GetSubtreeRootsArg, resp wa
 	if err != nil {
 		return err
 	}
-	for i := 0; i < int(arg.MaxEntries) && i < len(reply.Subtrees); i++ {
+	for i := 0; i < len(reply.Subtrees); i++ {
 		subtree := reply.Subtrees[i]
 		block, err := common.GetBlock(s.cache, subtree.End_height)
 		if block == nil {


### PR DESCRIPTION
We also remove the `i < maxEntries` bound on returned results, as the `limit` parameter already causes `zcashd` to bound its returned entries.

Closes zcash/lightwalletd#444.

Please ensure this checklist is followed for any pull requests for this repo. This checklist must be checked by both the PR creator and by anyone who reviews the PR.
* [ ] Relevant documentation for this PR has to be completed before the PR can be merged
* [ ] A test plan for the PR must be documented in the PR notes and included in the test plan for the next regular release

As a note, all CI tests need to be passing and all appropriate code reviews need to be done before this PR can be merged
