### PR TITLE
darkside GetTreeState gRPC: support block hash or height

### DIFF
--- a/frontend/service.go
+++ b/frontend/service.go
@@ -907,7 +907,7 @@ func (s *DarksideStreamer) AddTreeState(ctx context.Context, arg *walletrpc.Tree
 
 // removes a TreeState from the cache if present
 func (s *DarksideStreamer) RemoveTreeState(ctx context.Context, arg *walletrpc.BlockID) (*walletrpc.Empty, error) {
-	err := common.DarksideRemoveTreeState(arg.Height)
+	err := common.DarksideRemoveTreeState(arg)
 
 	return &walletrpc.Empty{}, err
 }


### PR DESCRIPTION
In production mode, the `GetTreeState` gRPC supports block specification by either height or block hash. But until now, darkside emulation only supports height. This commit adds support for block hash.

It also allows entries to be deleted (darkside `RemoveTreeState`) by block hash (not just height).

This is a test-only change.