### PR TITLE
darksidewallet: don't crash if GetLightdInfo is called when there are no blocks

### DIFF
--- a/common/darkside.go
+++ b/common/darkside.go
@@ -498,7 +498,10 @@ func darksideRawRequest(method string, params []json.RawMessage) (json.RawMessag
 		return json.Marshal(blockchaininfo)
 
 	case "getinfo":
-		info := &ZcashdRpcReplyGetinfo{}
+		info := &ZcashdRpcReplyGetinfo{
+			Build:      "darksidewallet-build",
+			Subversion: "darksidewallet-subversion",
+		}
 		return json.Marshal(info)
 
 	case "getblock":

--- a/common/darkside.go
+++ b/common/darkside.go
@@ -480,7 +480,8 @@ func darksideRawRequest(method string, params []json.RawMessage) (json.RawMessag
 	switch method {
 	case "getblockchaininfo":
 		if len(state.activeBlocks) == 0 {
-			Log.Fatal("getblockchaininfo: no blocks")
+			return nil, errors.New("GetLightdInfo requires at least one block, " +
+				"please stage and apply one or more blocks.")
 		}
 		index := state.latestHeight - state.startHeight
 		block := parser.NewBlock()


### PR DESCRIPTION
Closes #451.

darksidewallet: `GetLightdInfo` with no blocks shouldn't crash. Instead, return a reasonable error message.

This is a test-only change.

Also, one other small (somewhat unrelated) improvement, return non-empty strings for darkside's `GetLightdInfo`'s build information (`ZcashdBuild` and `ZcashdSubversion`). Empty strings don't seem best to return. We can't return real data here because, in darksidewallet mode, there is no `zcashd` running.

Side note, there's one other call to `Log.Fatal()` within `darksideRawRequest`, but it's in the `"getbestblockhash"` handler, which is only called by the block ingestor, and that thread doesn't run unless there are blocks. So we don't need to change that one (it's not callable from any gRPC directly).