### PR TITLE
fail during startup if rpcpassword not specified

### DIFF
--- a/frontend/rpc_client.go
+++ b/frontend/rpc_client.go
@@ -59,6 +59,10 @@ func connFromConf(confPath interface{}) (*rpcclient.ConnConfig, error) {
 	username := cfg.Section("").Key("rpcuser").String()
 	password := cfg.Section("").Key("rpcpassword").String()
 
+	if password == "" {
+		return nil, errors.New("rpcpassword not found (or empty), please add rpcpassword= to zcash.conf")
+	}
+
 	// Connect to local Zcash RPC server using HTTP POST mode.
 	connCfg := &rpcclient.ConnConfig{
 		Host:         net.JoinHostPort(rpcaddr, rpcport),


### PR DESCRIPTION
Closes #460.

Fatal error if `rpcpassword` isn't specified in `zcash.conf`. This is much better than endlessly retrying the initial `getblockchaininfo` RPC.