### PR TITLE
Bump golang version to mitigate HTTP/2 continuation floods (#478)

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: ['>=1.22.0']
+        go-version: ['>=1.22.2']
 
     steps:
       - name: Check out code


### PR DESCRIPTION
Triggers a CI build and release to Docker Hub using the latest Golang version, resolving #478.