### PR TITLE
Log gRPC startup listening when it is listening

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -119,13 +119,13 @@ func startServer(opts *common.Options) error {
 
 	logger.SetLevel(logrus.Level(opts.LogLevel))
 
+	logging.LogToStderr = opts.GRPCLogging
+
 	common.Log.WithFields(logrus.Fields{
 		"gitCommit": common.GitCommit,
 		"buildDate": common.BuildDate,
 		"buildUser": common.BuildUser,
-	}).Infof("Starting gRPC server version %s on %s", common.Version, opts.GRPCBindAddr)
-
-	logging.LogToStderr = opts.GRPCLogging
+	}).Infof("Starting lightwalletd process version %s", common.Version)
 
 	// gRPC initialization
 	var server *grpc.Server
@@ -281,6 +281,8 @@ func startServer(opts *common.Options) error {
 		}
 		walletrpc.RegisterDarksideStreamerServer(server, service)
 	}
+
+	common.Log.Infof("Starting gRPC server on %s", opts.GRPCBindAddr)
 
 	// Start listening
 	listener, err := net.Listen("tcp", opts.GRPCBindAddr)


### PR DESCRIPTION
UPDATE: this PR includes only the second change mentioned below, see #484 for the first change:

Lightwalletd can take upwards of 20 minutes to start when a block cache exists on a magnetic hard drive. When lightwalletd starts up for the first time, it is able to respond to gRPC nearly immediately while the block cache synchronizes in the background. It is confusing that upon second launch the time-to-first-listen is very slow.

This pull request contains two changes:
1. Load and maintain synchronization of the block cache in the background without blocking gRPC's first listen
2. Only announce that gRPC is listening once it is actually listening

This is a draft open to community review. I will test this in a staging environment for a few weeks before requesting a merge.

A Docker Hub image of this branch is available for testing at: emersonian/zcash-lwd:v0.4.17-cache1

---

Please ensure this checklist is followed for any pull requests for this repo. This checklist must be checked by both the PR creator and by anyone who reviews the PR.
* [x] Relevant documentation for this PR has to be completed before the PR can be merged
* [ ] A test plan for the PR must be documented in the PR notes and included in the test plan for the next regular release

As a note, all CI tests need to be passing and all appropriate code reviews need to be done before this PR can be merged
