### PR TITLE
add --nocache option to disable compact block file cache

### DIFF
--- a/common/cache.go
+++ b/common/cache.go
@@ -195,7 +195,7 @@ func NewBlockCache(dbPath string, chainName string, startHeight int, syncFromHei
 	c := &BlockCache{}
 	c.firstBlock = startHeight
 	c.nextBlock = startHeight
-	c.lengthsName, c.blocksName = dbFileNames(dbPath, chainName)
+	c.lengthsName, c.blocksName = DbFileNames(dbPath, chainName)
 	var err error
 	if err := os.MkdirAll(filepath.Join(dbPath, chainName), 0755); err != nil {
 		Log.Fatal("mkdir ", dbPath, " failed: ", err)
@@ -250,7 +250,7 @@ func NewBlockCache(dbPath string, chainName string, startHeight int, syncFromHei
 	return c
 }
 
-func dbFileNames(dbPath string, chainName string) (string, string) {
+func DbFileNames(dbPath string, chainName string) (string, string) {
 	return filepath.Join(dbPath, chainName, "lengths"),
 		filepath.Join(dbPath, chainName, "blocks")
 }

--- a/common/common.go
+++ b/common/common.go
@@ -43,6 +43,7 @@ type Options struct {
 	NoTLSVeryInsecure   bool   `json:"no_tls_very_insecure,omitempty"`
 	GenCertVeryInsecure bool   `json:"gen_cert_very_insecure,omitempty"`
 	Redownload          bool   `json:"redownload"`
+	NoCache             bool   `json:"nocache"`
 	SyncFromHeight      int    `json:"sync_from_height"`
 	DataDir             string `json:"data_dir"`
 	PingEnable          bool   `json:"ping_enable"`
@@ -476,9 +477,12 @@ func BlockIngestor(c *BlockCache, rep int) {
 // nil if no block exists at this height.
 func GetBlock(cache *BlockCache, height int) (*walletrpc.CompactBlock, error) {
 	// First, check the cache to see if we have the block
-	block := cache.Get(height)
-	if block != nil {
-		return block, nil
+	var block *walletrpc.CompactBlock
+	if cache != nil {
+		block := cache.Get(height)
+		if block != nil {
+			return block, nil
+		}
 	}
 
 	// Not in the cache


### PR DESCRIPTION
Closes #480. Enabling this option decreases the performance of gRPCs GetBlock and GetBlockRange, but conserves disk space (the current database size is about 17GB).

Note, specifying this option will also delete the existing cache (so if you start again without --nocache, the cache will need to be recreated).
