### PR TITLE
Reduce lightwalletd startup (if disk cache already exists)

### DIFF
--- a/common/cache.go
+++ b/common/cache.go
@@ -243,13 +243,6 @@ func NewBlockCache(dbPath string, chainName string, startHeight int, syncFromHei
 		}
 		offset += int64(length) + 8
 		c.starts = append(c.starts, offset)
-		// Check for corruption.
-		block := c.readBlock(c.nextBlock)
-		if block == nil {
-			Log.Warning("error reading block")
-			c.recoverFromCorruption(c.nextBlock)
-			break
-		}
 		c.nextBlock++
 	}
 	c.setDbFiles(c.nextBlock)


### PR DESCRIPTION
Reduce the startup time from a couple of minutes to a few seconds (or less) by removing the deserialization of all compact blocks in the disk cache. This is an alternative to PR #482, see comment there for details.