### PR TITLE
add the ability to parse zebrad.toml config file

### DIFF
--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -540,52 +540,6 @@ func TestSendTransaction(t *testing.T) {
 	step = 0
 }
 
-var sampleconf = `
-testnet = 1
-rpcport = 18232
-rpcbind = 127.0.0.1
-rpcuser = testlightwduser
-rpcpassword = testlightwdpassword
-`
-
-func TestNewZRPCFromConf(t *testing.T) {
-	connCfg, err := connFromConf([]byte(sampleconf))
-	if err != nil {
-		t.Fatal("connFromConf failed")
-	}
-	if connCfg.Host != "127.0.0.1:18232" {
-		t.Fatal("connFromConf returned unexpected Host")
-	}
-	if connCfg.User != "testlightwduser" {
-		t.Fatal("connFromConf returned unexpected User")
-	}
-	if connCfg.Pass != "testlightwdpassword" {
-		t.Fatal("connFromConf returned unexpected User")
-	}
-	if !connCfg.HTTPPostMode {
-		t.Fatal("connFromConf returned unexpected HTTPPostMode")
-	}
-	if !connCfg.DisableTLS {
-		t.Fatal("connFromConf returned unexpected DisableTLS")
-	}
-
-	// can't pass an integer
-	_, err = connFromConf(10)
-	if err == nil {
-		t.Fatal("connFromConf unexpected success")
-	}
-
-	// Can't verify returned values, but at least run it
-	_, err = NewZRPCFromConf([]byte(sampleconf))
-	if err != nil {
-		t.Fatal("NewZRPCFromClient failed")
-	}
-	_, err = NewZRPCFromConf(10)
-	if err == nil {
-		t.Fatal("NewZRPCFromClient unexpected success")
-	}
-}
-
 func TestMempoolFilter(t *testing.T) {
 	txidlist := []string{
 		"2e819d0bab5c819dc7d5f92d1bfb4127ce321daf847f6602",

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/zcash/lightwalletd
 go 1.17
 
 require (
+	github.com/BurntSushi/toml v0.3.1
 	github.com/btcsuite/btcd v0.24.0
 	github.com/golang/protobuf v1.5.3
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1136,6 +1136,7 @@ cloud.google.com/go/workflows v1.12.3/go.mod h1:fmOUeeqEwPzIU81foMjTRQIdwQHADi/v
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 gioui.org v0.0.0-20210308172011-57750fc8a0a6/go.mod h1:RSH6KIUZ0p2xy5zHDxgAM4zumjgTw83q2ge/PI+yyw8=
 git.sr.ht/~sbinet/gg v0.3.1/go.mod h1:KGYtlADtqsqANL9ueOFkWymvzUvLMQllU5Ixo+8v3pc=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=


### PR DESCRIPTION
Fixes #462. If the file extension is `.conf` (as in `zcash.conf`), then parse the file as an INI file (as is done today). If the extension is `.toml` (as in `zebrad.toml`), then interpret as TOML. The only possible problem is if the user has specified a toml config file (using `--zcash-conf-path`) that doesn't have the `.toml` extension. It will then be interpreted as a `.conf` (INI) file. But it's not unreasonable to require the toml extension.