### PR TITLE
Update CI - docker release

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -52,6 +52,7 @@ jobs:
       image_tags: ${{ needs.docker_set_env.outputs.tags }}
       dockerfile: ./Dockerfile
       context: .
+      build-args: ""
     secrets:
       dockerhub_registry: ${{ secrets.DOCKERHUB_REGISTRY }}
       dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
In this PR, an update is included in the way arguments are passed to the job that builds and releases the Docker image, because the template includes the possibility of passing arguments to the Dockerfile.