### PR TITLE
zebrad instead of zcashd in error messages

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -198,7 +198,7 @@ func startServer(opts *common.Options) error {
 		if err != nil {
 			common.Log.WithFields(logrus.Fields{
 				"error": err,
-			}).Fatal("setting up RPC connection to zcashd")
+			}).Fatal("setting up RPC connection to zebrad or zcashd")
 		}
 		// Indirect function for test mocking (so unit tests can talk to stub functions).
 		common.RawRequest = rpcClient.RawRequest
@@ -210,7 +210,7 @@ func startServer(opts *common.Options) error {
 		if err != nil {
 			common.Log.WithFields(logrus.Fields{
 				"error": err,
-			}).Fatal("getting initial information from zcashd")
+			}).Fatal("getting initial information from zebrad or zcashd")
 		}
 		common.Log.Info("Got sapling height ", getLightdInfo.SaplingActivationHeight,
 			" block height ", getLightdInfo.BlockHeight,
@@ -218,6 +218,10 @@ func startServer(opts *common.Options) error {
 			" branchID ", getLightdInfo.ConsensusBranchId)
 		saplingHeight = int(getLightdInfo.SaplingActivationHeight)
 		chainName = getLightdInfo.ChainName
+		if strings.Contains(getLightdInfo.ZcashdSubversion, "MagicBean") {
+			// The default is zebrad
+			common.NodeName = "zcashd"
+		}
 	}
 
 	dbPath := filepath.Join(opts.DataDir, "db")
@@ -339,12 +343,12 @@ func init() {
 	rootCmd.Flags().String("rpcport", "", "RPC host port")
 	rootCmd.Flags().Bool("no-tls-very-insecure", false, "run without the required TLS certificate, only for debugging, DO NOT use in production")
 	rootCmd.Flags().Bool("gen-cert-very-insecure", false, "run with self-signed TLS certificate, only for debugging, DO NOT use in production")
-	rootCmd.Flags().Bool("redownload", false, "re-fetch all blocks from zcashd; reinitialize local cache files")
+	rootCmd.Flags().Bool("redownload", false, "re-fetch all blocks from zebrad or zcashd; reinitialize local cache files")
 	rootCmd.Flags().Bool("nocache", false, "don't maintain a compact blocks disk cache (to reduce storage)")
-	rootCmd.Flags().Int("sync-from-height", -1, "re-fetch blocks from zcashd start at this height")
+	rootCmd.Flags().Int("sync-from-height", -1, "re-fetch blocks from zebrad or zcashd, starting at this height")
 	rootCmd.Flags().String("data-dir", "/var/lib/lightwalletd", "data directory (such as db)")
 	rootCmd.Flags().Bool("ping-very-insecure", false, "allow Ping GRPC for testing")
-	rootCmd.Flags().Bool("darkside-very-insecure", false, "run with GRPC-controllable mock zcashd for integration testing (shuts down after 30 minutes)")
+	rootCmd.Flags().Bool("darkside-very-insecure", false, "run with GRPC-controllable mock zebrad for integration testing (shuts down after 30 minutes)")
 	rootCmd.Flags().Int("darkside-timeout", 30, "override 30 minute default darkside timeout")
 
 	viper.BindPFlag("grpc-bind-addr", rootCmd.Flags().Lookup("grpc-bind-addr"))

--- a/common/common.go
+++ b/common/common.go
@@ -25,6 +25,7 @@ var (
 	Branch    = ""
 	BuildDate = ""
 	BuildUser = ""
+	NodeName  = "zebrad"
 )
 
 type Options struct {
@@ -225,7 +226,7 @@ func FirstRPC() {
 		if retryCount > 10 {
 			Log.WithFields(logrus.Fields{
 				"timeouts": retryCount,
-			}).Fatal("unable to issue getblockchaininfo RPC call to zcashd node")
+			}).Fatal("unable to issue getblockchaininfo RPC call to zebrad or zcashd node")
 		}
 		Log.WithFields(logrus.Fields{
 			"error": err.Error(),
@@ -418,7 +419,7 @@ func BlockIngestor(c *BlockCache, rep int) {
 		if err != nil {
 			Log.WithFields(logrus.Fields{
 				"error": err,
-			}).Fatal("error zcashd getbestblockhash rpc")
+			}).Fatal("error " + NodeName + " getbestblockhash rpc")
 		}
 		var hashHex string
 		err = json.Unmarshal(result, &hashHex)
@@ -462,7 +463,7 @@ func BlockIngestor(c *BlockCache, rep int) {
 		}
 		if height == c.GetFirstHeight() {
 			c.Sync()
-			Log.Info("Waiting for zcashd height to reach Sapling activation height ",
+			Log.Info("Waiting for "+NodeName+" height to reach Sapling activation height ",
 				"(", c.GetFirstHeight(), ")...")
 			Time.Sleep(20 * time.Second)
 			return

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -703,7 +703,7 @@ func TestMempoolStream(t *testing.T) {
 		t.Fatal("unexpected end time")
 	}
 	if step != 8 {
-		t.Fatal("unexpected number of zcashd RPCs")
+		t.Fatal("unexpected number of zebrad RPCs")
 	}
 
 	step = 0

--- a/frontend/service.go
+++ b/frontend/service.go
@@ -142,6 +142,7 @@ func (s *lwdStreamer) GetBlock(ctx context.Context, id *walletrpc.BlockID) (*wal
 	// Precedence: a hash is more specific than a height. If we have it, use it first.
 	if id.Hash != nil {
 		// TODO: Get block by hash
+		// see https://github.com/zcash/lightwalletd/pull/309
 		return nil, errors.New("gRPC GetBlock by Hash is not yet implemented")
 	}
 	cBlock, err := common.GetBlock(s.cache, int(id.Height))
@@ -162,6 +163,7 @@ func (s *lwdStreamer) GetBlockNullifiers(ctx context.Context, id *walletrpc.Bloc
 	// Precedence: a hash is more specific than a height. If we have it, use it first.
 	if id.Hash != nil {
 		// TODO: Get block by hash
+		// see https://github.com/zcash/lightwalletd/pull/309
 		return nil, errors.New("gRPC GetBlock by Hash is not yet implemented")
 	}
 	cBlock, err := common.GetBlock(s.cache, int(id.Height))
@@ -286,7 +288,7 @@ func (s *lwdStreamer) GetTreeState(ctx context.Context, id *walletrpc.BlockID) (
 		params[0] = hashJSON
 	}
 	if gettreestateReply.Sapling.Commitments.FinalState == "" {
-		return nil, errors.New("zcashd did not return treestate")
+		return nil, errors.New(common.NodeName + " did not return treestate")
 	}
 	return &walletrpc.TreeState{
 		Network:     s.chainName,


### PR DESCRIPTION
Closes #488. Indicate the correct backend process name in error messages. Some error messages occur before we know if our backend is `zcashd` or `zebrad` (for example, when we're attempting the first RPC), so those will mention both as possibilities. A follow-on PR could mention the backend name in additional error messages (this PR corrects the only two, only one of which is a gRPC, `GetTreeState()`, the other in the block ingestor). I did test this PR with an instance of `zebrad`.