### PR TITLE
wait for zebrad or zcashd to reach sapling activation height

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -464,8 +464,8 @@ func BlockIngestor(c *BlockCache, rep int) {
 			c.Sync()
 			Log.Info("Waiting for zcashd height to reach Sapling activation height ",
 				"(", c.GetFirstHeight(), ")...")
-			Time.Sleep(20 * time.Second)
-			return
+			Time.Sleep(120 * time.Second)
+			continue
 		}
 		Log.Info("REORG: dropping block ", height-1, " ", displayHash(c.GetLatestHash()))
 		c.Reorg(height - 1)


### PR DESCRIPTION
This has been broken for a long time. If, when starting up, `lightwalletd` discovers that the backend node (`zebrad` or `zcashd`) has not yet synced to the Sapling activation height (419200 for mainnet, 280000 for testnet), it should wait until that happens, then sync along with the backend node. But instead, `lightwalletd` gets stuck indefinitely. The only way to escape the hang is to stop and restart `lightwalletd` (after the backend has passed Sapling activation).

This commit fixes the problem; the block ingestor retries every 2 minutes (which was always the intention), rather than trying once and then giving up.

This bug isn't activated often; usually when `lightwalletd` starts, the backend node has already synced beyond the Sapling activation height. (That's why this bug wasn't noticed until now; I noticed it while testing `lightwalletd` with `zebrad` for a different PR.)

I tested this PR on both mainnet and testnet.