### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:1.22 AS lightwalletd_base
 
 ADD . /go/src/github.com/zcash/lightwalletd
 WORKDIR /go/src/github.com/zcash/lightwalletd
+
 RUN make \
   && /usr/bin/install -c ./lightwalletd /usr/local/bin/ \
   && mkdir -p /var/lib/lightwalletd/db \
@@ -10,13 +11,13 @@ RUN make \
 ARG LWD_USER=lightwalletd
 ARG LWD_UID=2002
 
-RUN useradd --home-dir /srv/$LWD_USER \
+RUN useradd --home-dir "/srv/$LWD_USER" \
             --shell /bin/bash \
             --create-home \
-            --uid $LWD_UID\
-            $LWD_USER
-USER $LWD_USER
-WORKDIR /srv/$LWD_USER
+            --uid "$LWD_UID" \
+            "$LWD_USER"
+
+WORKDIR "/srv/$LWD_USER"
 
 ENTRYPOINT ["lightwalletd"]
 CMD ["--help"]


### PR DESCRIPTION
The purpose of this change is to simplify the Dockerfile, enabling the Docker image to be run with a custom user without the need to build a custom image, but rather using the official version of the public image