### PR TITLE
non-functional change - re-run protoc to update comments

### DIFF
--- a/docs/rtd/index.html
+++ b/docs/rtd/index.html
@@ -1564,7 +1564,7 @@ replacing any existing entries</p></td>
         
       
         <h3 id="cash.z.wallet.sdk.rpc.RawTransaction">RawTransaction</h3>
-        <p>RawTransaction contains the complete transaction data. It also optionally includes </p><p>the block height in which the transaction was included, or, when returned</p><p>by GetMempoolStream(), the latest block height.</p>
+        <p>RawTransaction contains the complete transaction data. It also includes the</p><p>height for the block in which the transaction was included in the main</p><p>chain, if any (as detailed below).</p>
 
         
           <table class="field-table">
@@ -1577,14 +1577,31 @@ replacing any existing entries</p></td>
                   <td>data</td>
                   <td><a href="#bytes">bytes</a></td>
                   <td></td>
-                  <td><p>exact data returned by Zcash &#39;getrawtransaction&#39; </p></td>
+                  <td><p>The serialized representation of the Zcash transaction. </p></td>
                 </tr>
               
                 <tr>
                   <td>height</td>
                   <td><a href="#uint64">uint64</a></td>
                   <td></td>
-                  <td><p>height that the transaction was mined (or -1) </p></td>
+                  <td><p>The height at which the transaction is mined, or a sentinel value.
+
+Due to an error in the original protobuf definition, it is necessary to
+reinterpret the result of the `getrawtransaction` RPC call. Zcashd will
+return the int64 value `-1` for the height of transactions that appear
+in the block index, but which are not mined in the main chain. Here, the
+height field of `RawTransaction` was erroneously created as a `uint64`,
+and as such we must map the response from the zcashd RPC API to be
+representable within this space. Additionally, the `height` field will
+be absent for transactions in the mempool, resulting in the default
+value of `0` being set. Therefore, the meanings of the `height` field of
+the `RawTransaction` type are as follows:
+
+* height 0: the transaction is in the mempool
+* height 0xffffffffffffffff: the transaction has been mined on a fork that
+  is not currently the main chain
+* any other height: the transaction has been mined in the main chain at the
+  given height </p></td>
                 </tr>
               
             </tbody>


### PR DESCRIPTION
This is a follow-on to PR #495, which changed the comments in `service.proto` but didn't regenerate `service.pb.go`. This commits re-runs protoc so the two are back in sync (but the changes were comments only).
