### PR TITLE
fix GetLatestBlock gRPC reply block hash endianness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,21 @@ All notable changes to this library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The most recent changes are listed first.
 
 ## [Unreleased]
+
+### Added
+
+- Add debug logging to gRPC entry and exit points.
+
+- Add smoke test
+
+- lightwalletd node operators can export a donation address in the
+  GetLightdInfo gRPC.
+
+- Add the ability to not create and maintain a compact block cache.
+
 
 ### Changed
 
@@ -16,6 +29,17 @@ and this library adheres to Rust's notion of
   the semantics of this field.
 
 ### Fixed
+
+- GetLatestBlock should report latest block hash in little-endian
+  format, not big-endian.
+
+- Support empty block range end in `getaddresstxids` calls.
+
+- Filter out mined transactions in `refreshMempoolTxns`
+
+- Uniformly return height 0 for mempool `RawTransaction` results.
+
+- Reduce lightwalletd startup time.
 
 - Parsing of `getrawtransaction` results is now platform-independent.
   Previously, values of `-1` returned for the transaction height would

--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -34,6 +34,7 @@ const (
 	unitTestChain = "unittestnet"
 )
 
+// block 380640 used here is a real block from testnet
 func testsetup() (walletrpc.CompactTxStreamerServer, *common.BlockCache) {
 	os.RemoveAll(unitTestPath)
 	cache := common.NewBlockCache(unitTestPath, unitTestChain, 380640, 0)
@@ -173,7 +174,7 @@ func getLatestBlockStub(method string, params []json.RawMessage) (json.RawMessag
 		}
 		return []byte("{\"Blocks\": 380640, " +
 			"\"BestBlockHash\": " +
-			"\"913b07faeb835a29bd3a1727876fe1c65aaeb10c7cde36ccd038b2b3445e0a00\"}"), nil
+			"\"000a5e44b3b238d0cc36de7c0cb1ae5ac6e16f8727173abd295a83ebfa073b91\"}"), nil
 
 	case 4:
 		return nil, errors.New("getblock test error, too many requests")

--- a/frontend/service.go
+++ b/frontend/service.go
@@ -68,11 +68,13 @@ func (s *lwdStreamer) GetLatestBlock(ctx context.Context, placeholder *walletrpc
 	if err != nil {
 		return nil, err
 	}
-	bestBlockHash, err := hex.DecodeString(blockChainInfo.BestBlockHash)
+	bestBlockHashBigEndian, err := hex.DecodeString(blockChainInfo.BestBlockHash)
 	if err != nil {
 		return nil, err
 	}
-	r := &walletrpc.BlockID{Height: uint64(blockChainInfo.Blocks), Hash: []byte(bestBlockHash)}
+	// Binary block hash should always be in little-endian format
+	bestBlockHash := parser.Reverse(bestBlockHashBigEndian)
+	r := &walletrpc.BlockID{Height: uint64(blockChainInfo.Blocks), Hash: bestBlockHash}
 	common.Log.Tracef("  return: %+v\n", r)
 	return r, nil
 }


### PR DESCRIPTION
Closes #512
Return the hash of the latest block in little-endian order, rather than big-endian. This hash is a byte array, not a hex string, so it should be in little-endian format. It does not appear that anyone is depending on this fix at the moment (no one is using the hash result of this gRPC).