### PR TITLE
GetMempoolTx: report txid hash in little-endian

### DIFF
--- a/common/darkside.go
+++ b/common/darkside.go
@@ -760,7 +760,7 @@ func darksideGetRawTransaction(params []json.RawMessage) (json.RawMessage, error
 	if err != nil {
 		return nil, errors.New("failed to parse getrawtransaction JSON")
 	}
-	txid, err := hex.DecodeString(rawtx)
+	txidBigEndian, err := hex.DecodeString(rawtx)
 	if err != nil {
 		return nil, errors.New("-9: " + err.Error())
 	}
@@ -790,7 +790,7 @@ func darksideGetRawTransaction(params []json.RawMessage) (json.RawMessage, error
 		_, _ = block.ParseFromSlice(b)
 		darksideSetBlockTxID(block)
 		for _, tx := range block.Transactions() {
-			if bytes.Equal(tx.GetDisplayHash(), txid) {
+			if bytes.Equal(tx.GetDisplayHash(), txidBigEndian) {
 				return marshalReply(tx, block.GetHeight())
 			}
 		}
@@ -827,7 +827,7 @@ func darksideGetRawTransaction(params []json.RawMessage) (json.RawMessage, error
 		tx := parser.NewTransaction()
 		_, _ = tx.ParseFromSlice(stx.bytes)
 		darksideSetTxID(tx)
-		if bytes.Equal(tx.GetDisplayHash(), txid) {
+		if bytes.Equal(tx.GetDisplayHash(), txidBigEndian) {
 			return marshalReply(tx, 0), nil
 		}
 	}

--- a/smoke-test.bash
+++ b/smoke-test.bash
@@ -178,7 +178,7 @@ gt StageTransactions '{"height":663195,"url":"https://raw.githubusercontent.com/
 echo GetMempoolTx ...
 actual=$(gp GetMempoolTx '{"txid":""}')
 expected='{
-  "hash": "CCGom+fy/BMReSw/od0hcajN+y7/2YWQy9Xrzc/PSR8=",
+  "hash": "H0nPz83r1cuQhdn/LvvNqHEh3aE/LHkRE/zy55uoIQg=",
   "spends": [
     {
       "nf": "xrZLCu+Kbv6PXo8cqM+f25Hp55L2cm95bM68JwUnDHg="


### PR DESCRIPTION
Related to #513. `GetMempoolTx` returns the current contents of the mempool (shielded transactions only) as a stream. Each returned transaction includes its txid (hash) returned as a byte array (not as a hex string). As explained in #512, byte stream hashes should be little-endian, but this method incorrectly returns the txid in big-endian format. This PR fixes this bug, returning the hash in little-endian format.

I'm hesitant to merge this PR, because client software (wallets) could exist that already work around this error, that already expect the txid hash in big-endian format. 

Note that it's possible that no wallets use `GetMempoolTx` because there's a newer and better method, `GetMempoolStream` (which doesn't have this bug). If that's true, then it wouldn't hurt to merge this PR, but it wouldn't really be needed anyway (unless it begins to be used in the future). I'd appreciate any comments and advice from wallet devs on whether this PR should be merged or not.