### PR TITLE
bug: fix SIGSEGV during shutdown with --nocache (low-priority)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -302,7 +302,9 @@ func startServer(opts *common.Options) error {
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		s := <-signals
-		cache.Sync()
+		if cache != nil {
+			cache.Sync()
+		}
 		common.Log.WithFields(logrus.Fields{
 			"signal": s.String(),
 		}).Info("caught signal, stopping gRPC server")


### PR DESCRIPTION
Low-priority bugfix, follow-on to #483 - prevent segmentation fault when `lightwalletd` exits (for example, receives a control-C):
```
{"app":"lightwalletd","level":"info","msg":"Starting gRPC server on 127.0.0.1:9067","time":"2025-08-13T14:19:45-06:00"}
^Cpanic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xa92db3]

goroutine 12 [running]:
github.com/zcash/lightwalletd/common.(*BlockCache).Sync(0x0)
	/sd/g/lightwalletd/common/cache.go:384 +0x13
github.com/zcash/lightwalletd/cmd.startServer.func1()
	/sd/g/lightwalletd/cmd/root.go:305 +0x69
created by github.com/zcash/lightwalletd/cmd.startServer in goroutine 1
	/sd/g/lightwalletd/cmd/root.go:303 +0x1da9
exit status 2
```
The bug is that if `lightwalletd` is started with the `--nocache` configuration, the `cache` variable isn't set (is `nil`), but we're not testing it before dereferencing it during shutdown (after receiving a signal).

I verified that this variable, `cache`, cannot be changing while it's being tested (for `nil` value), because it's set (or not) earlier in this same function (before the asynchronous goroutine is launched). Although, that would have been a bug previously too.