### PR TITLE
Fix infinite loop in darkside setPrevhash (#552)

### DIFF
--- a/common/darkside.go
+++ b/common/darkside.go
@@ -232,6 +232,11 @@ func setPrevhash() {
 	prevhash := hash32.Nil
 	for _, activeBlock := range state.activeBlocks {
 		// Set this block's prevhash.
+		if prevhash != hash32.Nil {
+			copy(activeBlock.bytes[4:4+32], prevhash[:])
+		}
+		// Re-parse the block from the (possibly modified) bytes
+		// so that the hash we compute includes the updated prevhash.
 		block := parser.NewBlock()
 		rest, err := block.ParseFromSlice(activeBlock.bytes)
 		if err != nil {
@@ -239,9 +244,6 @@ func setPrevhash() {
 		}
 		if len(rest) != 0 {
 			Log.Fatal(errors.New("block is too long"))
-		}
-		if prevhash != hash32.Nil {
-			copy(activeBlock.bytes[4:4+32], prevhash[:])
 		}
 		prevhash = block.GetEncodableHash()
 		Log.Info("Darkside active block height ", block.GetHeight(), " hash ",

--- a/common/darkside.go
+++ b/common/darkside.go
@@ -235,8 +235,6 @@ func setPrevhash() {
 		if prevhash != hash32.Nil {
 			copy(activeBlock.bytes[4:4+32], prevhash[:])
 		}
-		// Re-parse the block from the (possibly modified) bytes
-		// so that the hash we compute includes the updated prevhash.
 		block := parser.NewBlock()
 		rest, err := block.ParseFromSlice(activeBlock.bytes)
 		if err != nil {

--- a/common/darkside_test.go
+++ b/common/darkside_test.go
@@ -1,0 +1,83 @@
+package common
+
+import (
+	"os"
+	"testing"
+
+	"github.com/zcash/lightwalletd/hash32"
+	"github.com/zcash/lightwalletd/parser"
+)
+
+// TestSetPrevhashChainConsistency verifies that after setPrevhash runs,
+// each block's prevhash matches the actual hash of the preceding block.
+// This is a regression test for issue #552, where setPrevhash computed
+// block hashes from stale (pre-update) bytes, causing an infinite
+// add/reorg loop in BlockIngestor.
+func TestSetPrevhashChainConsistency(t *testing.T) {
+	os.RemoveAll(unitTestPath)
+	defer os.RemoveAll(unitTestPath)
+	cache = NewBlockCache(unitTestPath, unitTestChain, 100, 0)
+	DarksideEnabled = true
+	defer func() { DarksideEnabled = false }()
+
+	state = darksideState{
+		resetted:               true,
+		startHeight:            100,
+		latestHeight:           -1,
+		branchID:               "bad",
+		chainName:              "test",
+		cache:                  cache,
+		activeBlocks:           make([]*activeBlock, 0),
+		stagedBlocks:           make([][]byte, 0),
+		incomingTransactions:   make([][]byte, 0),
+		stagedTransactions:     make([]stagedTx, 0),
+		stagedTreeStates:       make(map[uint64]*DarksideTreeState),
+		stagedTreeStatesByHash: make(map[string]*DarksideTreeState),
+	}
+
+	// Stage 5 empty blocks starting at height 100.
+	err := DarksideStageBlocksCreate(100, 0, 5)
+	if err != nil {
+		t.Fatal("DarksideStageBlocksCreate failed:", err)
+	}
+
+	// Move staged blocks to active and apply.
+	stagedBlocks := state.stagedBlocks
+	state.stagedBlocks = nil
+	for _, blockBytes := range stagedBlocks {
+		if err := addBlockActive(blockBytes); err != nil {
+			t.Fatal("addBlockActive failed:", err)
+		}
+	}
+
+	if len(state.activeBlocks) != 5 {
+		t.Fatal("expected 5 active blocks, got", len(state.activeBlocks))
+	}
+
+	// Run setPrevhash to link the chain.
+	setPrevhash()
+
+	// for each block after the first, its prevhash field
+	// must equal the hash of the preceding block (both computed from
+	// the final raw bytes).
+	var prevHash hash32.T
+	for i, ab := range state.activeBlocks {
+		block := parser.NewBlock()
+		rest, err := block.ParseFromSlice(ab.bytes)
+		if err != nil {
+			t.Fatalf("block %d: ParseFromSlice failed: %v", i, err)
+		}
+		if len(rest) != 0 {
+			t.Fatalf("block %d: trailing bytes after parse", i)
+		}
+
+		if i > 0 {
+			blockPrevHash := block.GetPrevHash()
+			if blockPrevHash != prevHash {
+				t.Errorf("block %d (height %d): prevhash mismatch\n  got:  %x\n  want: %x",
+					i, block.GetHeight(), blockPrevHash, prevHash)
+			}
+		}
+		prevHash = block.GetEncodableHash()
+	}
+}

--- a/common/darkside_test.go
+++ b/common/darkside_test.go
@@ -15,8 +15,9 @@ import (
 // add/reorg loop in BlockIngestor.
 func TestSetPrevhashChainConsistency(t *testing.T) {
 	os.RemoveAll(unitTestPath)
-	defer os.RemoveAll(unitTestPath)
 	cache = NewBlockCache(unitTestPath, unitTestChain, 100, 0)
+	defer os.RemoveAll(unitTestPath)
+	defer cache.Close()
 	DarksideEnabled = true
 	defer func() { DarksideEnabled = false }()
 


### PR DESCRIPTION
### Description:
Fix infinite loop in darkside setPrevhash by computing block hash after updating prevhash bytes.

### Summary
`setPrevhash()` was parsing each block's raw bytes *before* writing the corrected prevhash, then computing the block hash from the stale parsed struct. This caused subsequent blocks to have incorrect prevhash values, leading `BlockIngestor` into an infinite add/reorg loop when `ApplyStaged` was called.

The fix moves the `copy()` of the prevhash to occur before `ParseFromSlice()`, so the hash is computed from the updated bytes.

Closes #552

### Documentation
No external documentation changes required. The fix corrects internal behavior to match the existing documented darkside tutorial in `docs/darksidewalletd.md`.

### Test Plan
  - [x] Added regression test `TestSetPrevhashChainConsistency` in `common/darkside_test.go`
  - [x] Test verifies that each block's prevhash matches the preceding block's hash after `setPrevhash` runs
  - [x] Test fails against the old (buggy) code and passes with the fix
  - [x] All existing tests pass (`go test ./...`)
  - [ ] Manual verification: run the darkside tutorial from `docs/darksidewalletd.md` and confirm `ApplyStaged` no longer produces infinite log output
