### PR TITLE
Bound parser counts before allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ The most recent changes are listed first.
 
 ### Fixed
 
+- Bound element counts in the block and transaction parser against the
+  remaining input before allocating. A malformed or truncated serialization
+  can declare far more elements (transaction inputs and outputs, Sapling
+  spends and outputs, Orchard actions, JoinSplits, and the block's
+  transaction count) than the input could possibly contain; sizing a slice
+  from such a count previously allocated gigabytes before the first element
+  failed to parse, exhausting memory (GHSA-ph5v-77v6-j498).
+
 - Make `common.RawRequest` context-aware so cancelled `GetBlockRange` /
   `GetBlockRangeNullifiers` streams abort in-flight zcashd JSON-RPC calls
   instead of holding a goroutine and RPC connection until the request

--- a/parser/block.go
+++ b/parser/block.go
@@ -72,6 +72,7 @@ func (b *Block) GetDisplayPrevHashString() string {
 
 // see https://github.com/zcash/lightwalletd/issues/17#issuecomment-467110828
 const genesisTargetDifficulty = 520617983
+const minTransactionWireBytes = 5 // 4-byte header + at least one CompactSize byte
 
 // GetHeight extracts the block height from the coinbase transaction. See
 // BIP34. Returns block height on success, or -1 on error.
@@ -138,6 +139,9 @@ func (b *Block) ParseFromSlice(data []byte) (rest []byte, err error) {
 	var txCount int
 	if !s.ReadCompactSize(&txCount) {
 		return nil, errors.New("could not read tx_count")
+	}
+	if err := rejectCountExceedingRemaining("tx_count", txCount, len(s), minTransactionWireBytes); err != nil {
+		return nil, err
 	}
 	data = []byte(s)
 

--- a/parser/block.go
+++ b/parser/block.go
@@ -72,7 +72,6 @@ func (b *Block) GetDisplayPrevHashString() string {
 
 // see https://github.com/zcash/lightwalletd/issues/17#issuecomment-467110828
 const genesisTargetDifficulty = 520617983
-const minTransactionWireBytes = 5 // 4-byte header + at least one CompactSize byte
 
 // GetHeight extracts the block height from the coinbase transaction. See
 // BIP34. Returns block height on success, or -1 on error.

--- a/parser/block_header.go
+++ b/parser/block_header.go
@@ -181,6 +181,9 @@ func (hdr *BlockHeader) ParseFromSlice(in []byte) (rest []byte, err error) {
 		if !s.ReadCompactSize(&length) {
 			return in, errors.New("could not read compact size of solution")
 		}
+		if err := rejectCountExceedingRemaining("solution_length", length, len(s), 1); err != nil {
+			return in, err
+		}
 		hdr.Solution = make([]byte, length)
 		if !s.ReadBytes(&hdr.Solution, length) {
 			return in, errors.New("could not read CompactSize-prefixed Equihash solution")

--- a/parser/block_header.go
+++ b/parser/block_header.go
@@ -11,6 +11,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/zcash/lightwalletd/hash32"
@@ -181,8 +182,12 @@ func (hdr *BlockHeader) ParseFromSlice(in []byte) (rest []byte, err error) {
 		if !s.ReadCompactSize(&length) {
 			return in, errors.New("could not read compact size of solution")
 		}
-		if err := rejectCountExceedingRemaining("solution_length", length, len(s), 1); err != nil {
-			return in, err
+		// Check before allocating: length is a byte count bounded only by
+		// maxCompactSize, so a truncated header could otherwise size a 32MB
+		// slice that the ReadBytes below immediately fails to fill.
+		if length > len(s) {
+			return in, fmt.Errorf("solution_length %d exceeds remaining input length %d",
+				length, len(s))
 		}
 		hdr.Solution = make([]byte, length)
 		if !s.ReadBytes(&hdr.Solution, length) {

--- a/parser/block_header_test.go
+++ b/parser/block_header_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"math/big"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/zcash/lightwalletd/hash32"
@@ -180,6 +181,24 @@ func TestBadBlockHeader(t *testing.T) {
 		if err == nil {
 			t.Errorf("unexpected success parsing bad block %d", i)
 		}
+	}
+}
+
+func TestBlockHeaderRejectsSolutionLengthThatCannotFit(t *testing.T) {
+	// 140-byte block header prefix followed by solution_length=1 and no
+	// solution bytes.
+	blockData := make([]byte, 140)
+	blockData[0] = 0x04
+	blockData = append(blockData, 0x01)
+
+	blockHeader := NewBlockHeader()
+	_, err := blockHeader.ParseFromSlice(blockData)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	wantErr := "solution_length 1 exceeds remaining input length 0"
+	if !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf("error mismatch:\nhave: %v\nwant substring: %s", err, wantErr)
 	}
 }
 

--- a/parser/block_test.go
+++ b/parser/block_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	protobuf "github.com/golang/protobuf/proto"
@@ -72,4 +73,23 @@ func TestCompactBlocks(t *testing.T) {
 		}
 	}
 
+}
+
+func TestParseBlockRejectsTransactionCountThatCannotFit(t *testing.T) {
+	// 141-byte block header with version=4, zero-valued header fields, and an
+	// empty CompactSize-prefixed Equihash solution, followed by tx_count=1 and
+	// no transaction bytes.
+	blockData := make([]byte, 141)
+	blockData[0] = 0x04
+	blockData = append(blockData, 0x01)
+
+	block := NewBlock()
+	_, err := block.ParseFromSlice(blockData)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	wantErr := "tx_count 1 exceeds remaining input length 0"
+	if !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf("error mismatch:\nhave: %v\nwant substring: %s", err, wantErr)
+	}
 }

--- a/parser/block_test.go
+++ b/parser/block_test.go
@@ -88,7 +88,7 @@ func TestParseBlockRejectsTransactionCountThatCannotFit(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	wantErr := "tx_count 1 exceeds remaining input length 0"
+	wantErr := "tx_count 1 requires at least 10 bytes, but only 0 remain"
 	if !strings.Contains(err.Error(), wantErr) {
 		t.Fatalf("error mismatch:\nhave: %v\nwant substring: %s", err, wantErr)
 	}

--- a/parser/bounds.go
+++ b/parser/bounds.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2019-present The Zcash developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+package parser
+
+import "fmt"
+
+// A CompactSize count is only bounded by maxCompactSize (2^25), so a malformed
+// or truncated serialization can name far more elements than the input could
+// possibly contain. Sizing a slice from such a count allocates gigabytes before
+// the first element fails to parse. The constants below give the smallest
+// number of bytes each element can occupy on the wire, so a count can be
+// rejected against the remaining input before anything is allocated.
+//
+// Every constant here is the number of bytes consumed by one iteration of the
+// loop that parses these elements. Where an element also has per-element bytes
+// in a later section of the serialization (v5 Sapling spends carry a 192-byte
+// proof and a 64-byte signature in trailing vectors, for example), those are
+// deliberately not counted. That makes the bounds looser than the true minimum,
+// which is the safe direction: the check must never reject input that would
+// have parsed. Do not "tighten" these to the full per-element size.
+const (
+	// A v1 transaction: 4-byte header, tx_in_count, tx_out_count, nLockTime.
+	minTransactionWireBytes = 10
+
+	minTxInWireBytes  = 41 // 32-byte prevout hash + 4-byte index + 1-byte script length + 4-byte sequence
+	minTxOutWireBytes = 9  // 8-byte value + 1-byte script length
+
+	minSaplingV4SpendBytes  = 384 // cv + anchor + nullifier + rk + zkproof + spendAuthSig
+	minSaplingV4OutputBytes = 948 // cv + cmu + ephemeralKey + encCiphertext + outCiphertext + zkproof
+
+	minSaplingV5SpendBytes  = 96  // cv + nullifier + rk
+	minSaplingV5OutputBytes = 756 // cv + cmu + ephemeralKey + encCiphertext + outCiphertext
+
+	minOrchardActionBytes = 820 // cv + nullifier + rk + cmx + ephemeralKey + encCiphertext + outCiphertext
+
+	// vpubOld + vpubNew + anchor + nullifiers + commitments + ephemeralKey +
+	// randomSeed + vmacs + proof + encCiphertexts. See section 5.4.10.2 of the
+	// Zcash protocol spec; only the proof size differs between the two.
+	minJoinSplitGrothBytes = 1698
+	minJoinSplitPHGRBytes  = 1802
+)
+
+// rejectCountExceedingRemaining reports an error if count elements of at least
+// minElementBytes each cannot fit in remaining bytes of input. label names the
+// count field for the error message. minElementBytes must be positive.
+func rejectCountExceedingRemaining(label string, count int, remaining int, minElementBytes int) error {
+	if minElementBytes < 1 {
+		// Programming error; a zero would panic on the division below.
+		return fmt.Errorf("invalid minimum element size %d for %s", minElementBytes, label)
+	}
+	// Divide rather than computing count*minElementBytes, which can overflow a
+	// 32-bit int (maxCompactSize is 2^25). The truncating division only ever
+	// makes the bound looser, never tighter.
+	if count > remaining/minElementBytes {
+		return fmt.Errorf("%s %d requires at least %d bytes, but only %d remain",
+			label, count, int64(count)*int64(minElementBytes), remaining)
+	}
+	return nil
+}
+
+func minJoinSplitWireBytes(isGroth16Proof bool) int {
+	if isGroth16Proof {
+		return minJoinSplitGrothBytes
+	}
+	return minJoinSplitPHGRBytes
+}

--- a/parser/transaction.go
+++ b/parser/transaction.go
@@ -108,12 +108,41 @@ func (toutput *txOut) ToCompact() *walletrpc.TxOut {
 	}
 }
 
+const (
+	minTxInWireBytes        = 41  // 32-byte prevout hash + 4-byte index + 1-byte script length + 4-byte sequence
+	minTxOutWireBytes       = 9   // 8-byte value + 1-byte script length
+	minSaplingV4SpendBytes  = 384 // cv + anchor + nullifier + rk + zkproof + spendAuthSig
+	minSaplingV4OutputBytes = 948 // cv + cmu + ephemeralKey + encCiphertext + outCiphertext + zkproof
+	minSaplingV5SpendBytes  = 96  // cv + nullifier + rk
+	minSaplingV5OutputBytes = 756 // cv + cmu + ephemeralKey + encCiphertext + outCiphertext
+	minOrchardActionBytes   = 820 // cv + nullifier + rk + cmx + ephemeralKey + encCiphertext + outCiphertext
+	minJoinSplitGrothBytes  = 1698
+	minJoinSplitPHGRBytes   = 1802
+)
+
+func rejectCountExceedingRemaining(label string, count int, remaining int, minElementBytes int) error {
+	if count > remaining/minElementBytes {
+		return fmt.Errorf("%s %d exceeds remaining input length %d", label, count, remaining)
+	}
+	return nil
+}
+
+func minJoinSplitWireBytes(isGroth16Proof bool) int {
+	if isGroth16Proof {
+		return minJoinSplitGrothBytes
+	}
+	return minJoinSplitPHGRBytes
+}
+
 // parse the transparent parts of the transaction
 func (tx *Transaction) ParseTransparent(data []byte) ([]byte, error) {
 	s := bytestring.String(data)
 	var txInCount int
 	if !s.ReadCompactSize(&txInCount) {
 		return nil, errors.New("could not read tx_in_count")
+	}
+	if err := rejectCountExceedingRemaining("tx_in_count", txInCount, len(s), minTxInWireBytes); err != nil {
+		return nil, err
 	}
 	var err error
 	tx.transparentInputs = make([]txIn, txInCount)
@@ -128,6 +157,9 @@ func (tx *Transaction) ParseTransparent(data []byte) ([]byte, error) {
 	var txOutCount int
 	if !s.ReadCompactSize(&txOutCount) {
 		return nil, errors.New("could not read tx_out_count")
+	}
+	if err := rejectCountExceedingRemaining("tx_out_count", txOutCount, len(s), minTxOutWireBytes); err != nil {
+		return nil, err
 	}
 	tx.transparentOutputs = make([]txOut, txOutCount)
 	for i := 0; i < txOutCount; i++ {
@@ -467,6 +499,9 @@ func (tx *Transaction) parsePreV5(data []byte) ([]byte, error) {
 			if !s.ReadCompactSize(&spendCount) {
 				return nil, errors.New("could not read nShieldedSpend")
 			}
+			if err := rejectCountExceedingRemaining("nShieldedSpend", spendCount, len(s), minSaplingV4SpendBytes); err != nil {
+				return nil, err
+			}
 			tx.shieldedSpends = make([]spend, spendCount)
 			for i := 0; i < spendCount; i++ {
 				newSpend := &tx.shieldedSpends[i]
@@ -477,6 +512,9 @@ func (tx *Transaction) parsePreV5(data []byte) ([]byte, error) {
 			}
 			if !s.ReadCompactSize(&outputCount) {
 				return nil, errors.New("could not read nShieldedOutput")
+			}
+			if err := rejectCountExceedingRemaining("nShieldedOutput", outputCount, len(s), minSaplingV4OutputBytes); err != nil {
+				return nil, err
 			}
 			tx.shieldedOutputs = make([]output, outputCount)
 			for i := 0; i < outputCount; i++ {
@@ -491,6 +529,9 @@ func (tx *Transaction) parsePreV5(data []byte) ([]byte, error) {
 		var joinSplitCount int
 		if !s.ReadCompactSize(&joinSplitCount) {
 			return nil, errors.New("could not read nJoinSplit")
+		}
+		if err := rejectCountExceedingRemaining("nJoinSplit", joinSplitCount, len(s), minJoinSplitWireBytes(tx.isGroth16Proof())); err != nil {
+			return nil, err
 		}
 
 		tx.joinSplits = make([]joinSplit, joinSplitCount)
@@ -618,6 +659,9 @@ func (tx *Transaction) parseSaplingBundle(data []byte) ([]byte, error) {
 	if !s.ReadCompactSize(&spendCount) {
 		return nil, errors.New("could not read nShieldedSpend")
 	}
+	if err := rejectCountExceedingRemaining("nShieldedSpend", spendCount, len(s), minSaplingV5SpendBytes); err != nil {
+		return nil, err
+	}
 	if spendCount >= (1 << 16) {
 		return nil, fmt.Errorf("spentCount (%d) must be less than 2^16", spendCount)
 	}
@@ -631,6 +675,9 @@ func (tx *Transaction) parseSaplingBundle(data []byte) ([]byte, error) {
 	}
 	if !s.ReadCompactSize(&outputCount) {
 		return nil, errors.New("could not read nShieldedOutput")
+	}
+	if err := rejectCountExceedingRemaining("nShieldedOutput", outputCount, len(s), minSaplingV5OutputBytes); err != nil {
+		return nil, err
 	}
 	if outputCount >= (1 << 16) {
 		return nil, fmt.Errorf("outputCount (%d) must be less than 2^16", outputCount)
@@ -673,6 +720,9 @@ func parseOrchardActionShapeBundle(data []byte, pool string) ([]byte, []action, 
 	var actionsCount int
 	if !s.ReadCompactSize(&actionsCount) {
 		return nil, nil, fmt.Errorf("could not read nActions%s", pool)
+	}
+	if err := rejectCountExceedingRemaining("nActionsOrchard", actionsCount, len(s), minOrchardActionBytes); err != nil {
+		return nil, nil, err
 	}
 	if actionsCount >= (1 << 16) {
 		return nil, nil, fmt.Errorf("actionsCount (%d) must be less than 2^16", actionsCount)

--- a/parser/transaction.go
+++ b/parser/transaction.go
@@ -108,32 +108,6 @@ func (toutput *txOut) ToCompact() *walletrpc.TxOut {
 	}
 }
 
-const (
-	minTxInWireBytes        = 41  // 32-byte prevout hash + 4-byte index + 1-byte script length + 4-byte sequence
-	minTxOutWireBytes       = 9   // 8-byte value + 1-byte script length
-	minSaplingV4SpendBytes  = 384 // cv + anchor + nullifier + rk + zkproof + spendAuthSig
-	minSaplingV4OutputBytes = 948 // cv + cmu + ephemeralKey + encCiphertext + outCiphertext + zkproof
-	minSaplingV5SpendBytes  = 96  // cv + nullifier + rk
-	minSaplingV5OutputBytes = 756 // cv + cmu + ephemeralKey + encCiphertext + outCiphertext
-	minOrchardActionBytes   = 820 // cv + nullifier + rk + cmx + ephemeralKey + encCiphertext + outCiphertext
-	minJoinSplitGrothBytes  = 1698
-	minJoinSplitPHGRBytes   = 1802
-)
-
-func rejectCountExceedingRemaining(label string, count int, remaining int, minElementBytes int) error {
-	if count > remaining/minElementBytes {
-		return fmt.Errorf("%s %d exceeds remaining input length %d", label, count, remaining)
-	}
-	return nil
-}
-
-func minJoinSplitWireBytes(isGroth16Proof bool) int {
-	if isGroth16Proof {
-		return minJoinSplitGrothBytes
-	}
-	return minJoinSplitPHGRBytes
-}
-
 // parse the transparent parts of the transaction
 func (tx *Transaction) ParseTransparent(data []byte) ([]byte, error) {
 	s := bytestring.String(data)
@@ -663,7 +637,7 @@ func (tx *Transaction) parseSaplingBundle(data []byte) ([]byte, error) {
 		return nil, err
 	}
 	if spendCount >= (1 << 16) {
-		return nil, fmt.Errorf("spentCount (%d) must be less than 2^16", spendCount)
+		return nil, fmt.Errorf("spendCount (%d) must be less than 2^16", spendCount)
 	}
 	tx.shieldedSpends = make([]spend, spendCount)
 	for i := 0; i < spendCount; i++ {
@@ -721,7 +695,7 @@ func parseOrchardActionShapeBundle(data []byte, pool string) ([]byte, []action, 
 	if !s.ReadCompactSize(&actionsCount) {
 		return nil, nil, fmt.Errorf("could not read nActions%s", pool)
 	}
-	if err := rejectCountExceedingRemaining("nActionsOrchard", actionsCount, len(s), minOrchardActionBytes); err != nil {
+	if err := rejectCountExceedingRemaining("nActions"+pool, actionsCount, len(s), minOrchardActionBytes); err != nil {
 		return nil, nil, err
 	}
 	if actionsCount >= (1 << 16) {

--- a/parser/transaction_test.go
+++ b/parser/transaction_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -248,5 +249,140 @@ func appendOrchardLikeBundle(raw *bytes.Buffer, actionsCount int) {
 		raw.WriteByte(0x00)                      // proofs length
 		raw.Write(make([]byte, 64*actionsCount)) // spend auth signatures
 		raw.Write(make([]byte, 64))              // binding signature
+	}
+}
+
+func TestParseTransparentRejectsCountsThatCannotFit(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    []byte
+		wantErr string
+	}{
+		{
+			name:    "transparent inputs",
+			data:    []byte{0x01},
+			wantErr: "tx_in_count 1 exceeds remaining input length 0",
+		},
+		{
+			name:    "transparent outputs",
+			data:    []byte{0x00, 0x01},
+			wantErr: "tx_out_count 1 exceeds remaining input length 0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tx := NewTransaction()
+			_, err := tx.ParseTransparent(tt.data)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error mismatch:\nhave: %v\nwant substring: %s", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func requireErrorContains(t *testing.T, err error, want string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error mismatch:\nhave: %v\nwant substring: %s", err, want)
+	}
+}
+
+func saplingV4Prefix() []byte {
+	return []byte{
+		0x00,                   // tx_in_count
+		0x00,                   // tx_out_count
+		0x00, 0x00, 0x00, 0x00, // nLockTime
+		0x00, 0x00, 0x00, 0x00, // nExpiryHeight
+		0x00, 0x00, 0x00, 0x00, // valueBalance
+		0x00, 0x00, 0x00, 0x00,
+	}
+}
+
+func TestParsePreV5RejectsCountsThatCannotFit(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    []byte
+		wantErr string
+	}{
+		{
+			name:    "sapling spends",
+			data:    append(saplingV4Prefix(), 0x01),
+			wantErr: "nShieldedSpend 1 exceeds remaining input length 0",
+		},
+		{
+			name:    "sapling outputs",
+			data:    append(saplingV4Prefix(), 0x00, 0x01),
+			wantErr: "nShieldedOutput 1 exceeds remaining input length 0",
+		},
+		{
+			name:    "join splits",
+			data:    append(saplingV4Prefix(), 0x00, 0x00, 0x01),
+			wantErr: "nJoinSplit 1 exceeds remaining input length 0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tx := NewTransaction()
+			tx.fOverwintered = true
+			tx.version = SAPLING_TX_VERSION
+			tx.nVersionGroupID = SAPLING_VERSION_GROUP_ID
+
+			_, err := tx.parsePreV5(tt.data)
+			requireErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func zip225V5Prefix() []byte {
+	return []byte{
+		0x00, 0x00, 0x00, 0x00, // nConsensusBranchId
+		0x00, 0x00, 0x00, 0x00, // nLockTime
+		0x00, 0x00, 0x00, 0x00, // nExpiryHeight
+		0x00, // tx_in_count
+		0x00, // tx_out_count
+	}
+}
+
+func TestParseV5RejectsCountsThatCannotFit(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    []byte
+		wantErr string
+	}{
+		{
+			name:    "sapling spends",
+			data:    append(zip225V5Prefix(), 0x01),
+			wantErr: "nShieldedSpend 1 exceeds remaining input length 0",
+		},
+		{
+			name:    "sapling outputs",
+			data:    append(zip225V5Prefix(), 0x00, 0x01),
+			wantErr: "nShieldedOutput 1 exceeds remaining input length 0",
+		},
+		{
+			name:    "orchard actions",
+			data:    append(zip225V5Prefix(), 0x00, 0x00, 0x01),
+			wantErr: "nActionsOrchard 1 exceeds remaining input length 0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tx := NewTransaction()
+			tx.fOverwintered = true
+			tx.version = ZIP225_TX_VERSION
+			tx.nVersionGroupID = ZIP225_VERSION_GROUP_ID
+
+			_, err := tx.parseV5(tt.data)
+			requireErrorContains(t, err, tt.wantErr)
+		})
 	}
 }

--- a/parser/transaction_test.go
+++ b/parser/transaction_test.go
@@ -261,12 +261,19 @@ func TestParseTransparentRejectsCountsThatCannotFit(t *testing.T) {
 		{
 			name:    "transparent inputs",
 			data:    []byte{0x01},
-			wantErr: "tx_in_count 1 exceeds remaining input length 0",
+			wantErr: "tx_in_count 1 requires at least 41 bytes, but only 0 remain",
 		},
 		{
 			name:    "transparent outputs",
 			data:    []byte{0x00, 0x01},
-			wantErr: "tx_out_count 1 exceeds remaining input length 0",
+			wantErr: "tx_out_count 1 requires at least 9 bytes, but only 0 remain",
+		},
+		{
+			// A count far larger than one, with a non-trivial amount of input
+			// left, to exercise the division rather than the count==1 edge.
+			name:    "many transparent outputs",
+			data:    append([]byte{0x00, 0xfd, 0xe8, 0x03}, make([]byte, 100)...),
+			wantErr: "tx_out_count 1000 requires at least 9000 bytes, but only 100 remain",
 		},
 	}
 
@@ -281,6 +288,36 @@ func TestParseTransparentRejectsCountsThatCannotFit(t *testing.T) {
 				t.Fatalf("error mismatch:\nhave: %v\nwant substring: %s", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// The bounds checks must never reject input that would otherwise have parsed.
+// Feed each check a structure holding exactly its minimum-size elements, so a
+// bound that was tightened by even one byte would fail here.
+func TestBoundsChecksAcceptMinimallySizedElements(t *testing.T) {
+	var raw bytes.Buffer
+	raw.WriteByte(0x01)         // tx_in_count
+	raw.Write(make([]byte, 32)) // prevout hash
+	raw.Write(make([]byte, 4))  // prevout index
+	raw.WriteByte(0x00)         // script length (empty script)
+	raw.Write(make([]byte, 4))  // sequence
+	raw.WriteByte(0x01)         // tx_out_count
+	raw.Write(make([]byte, 8))  // value
+	raw.WriteByte(0x00)         // script length (empty script)
+
+	tx := NewTransaction()
+	rest, err := tx.ParseTransparent(raw.Bytes())
+	if err != nil {
+		t.Fatalf("minimally sized transparent elements rejected: %v", err)
+	}
+	if len(rest) != 0 {
+		t.Fatalf("did not consume entire buffer, %d remaining", len(rest))
+	}
+	if len(tx.transparentInputs) != 1 {
+		t.Fatal("tx_in_count miscompare")
+	}
+	if len(tx.transparentOutputs) != 1 {
+		t.Fatal("tx_out_count miscompare")
 	}
 }
 
@@ -300,7 +337,7 @@ func saplingV4Prefix() []byte {
 		0x00,                   // tx_out_count
 		0x00, 0x00, 0x00, 0x00, // nLockTime
 		0x00, 0x00, 0x00, 0x00, // nExpiryHeight
-		0x00, 0x00, 0x00, 0x00, // valueBalance
+		0x00, 0x00, 0x00, 0x00, // valueBalanceSapling (int64)
 		0x00, 0x00, 0x00, 0x00,
 	}
 }
@@ -314,17 +351,17 @@ func TestParsePreV5RejectsCountsThatCannotFit(t *testing.T) {
 		{
 			name:    "sapling spends",
 			data:    append(saplingV4Prefix(), 0x01),
-			wantErr: "nShieldedSpend 1 exceeds remaining input length 0",
+			wantErr: "nShieldedSpend 1 requires at least 384 bytes, but only 0 remain",
 		},
 		{
 			name:    "sapling outputs",
 			data:    append(saplingV4Prefix(), 0x00, 0x01),
-			wantErr: "nShieldedOutput 1 exceeds remaining input length 0",
+			wantErr: "nShieldedOutput 1 requires at least 948 bytes, but only 0 remain",
 		},
 		{
 			name:    "join splits",
 			data:    append(saplingV4Prefix(), 0x00, 0x00, 0x01),
-			wantErr: "nJoinSplit 1 exceeds remaining input length 0",
+			wantErr: "nJoinSplit 1 requires at least 1698 bytes, but only 0 remain",
 		},
 	}
 
@@ -360,17 +397,17 @@ func TestParseV5RejectsCountsThatCannotFit(t *testing.T) {
 		{
 			name:    "sapling spends",
 			data:    append(zip225V5Prefix(), 0x01),
-			wantErr: "nShieldedSpend 1 exceeds remaining input length 0",
+			wantErr: "nShieldedSpend 1 requires at least 96 bytes, but only 0 remain",
 		},
 		{
 			name:    "sapling outputs",
 			data:    append(zip225V5Prefix(), 0x00, 0x01),
-			wantErr: "nShieldedOutput 1 exceeds remaining input length 0",
+			wantErr: "nShieldedOutput 1 requires at least 756 bytes, but only 0 remain",
 		},
 		{
 			name:    "orchard actions",
 			data:    append(zip225V5Prefix(), 0x00, 0x00, 0x01),
-			wantErr: "nActionsOrchard 1 exceeds remaining input length 0",
+			wantErr: "nActionsOrchard 1 requires at least 820 bytes, but only 0 remain",
 		},
 	}
 
@@ -383,6 +420,18 @@ func TestParseV5RejectsCountsThatCannotFit(t *testing.T) {
 
 			_, err := tx.parseV5(tt.data)
 			requireErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+// The action bundle parser is shared between Orchard and Ironwood, so the
+// bound must name whichever pool it was called for.
+func TestParseOrchardActionShapeBundleNamesItsPool(t *testing.T) {
+	for _, pool := range []string{"Orchard", "Ironwood"} {
+		t.Run(pool, func(t *testing.T) {
+			_, _, err := parseOrchardActionShapeBundle([]byte{0x01}, pool)
+			requireErrorContains(t, err,
+				"nActions"+pool+" 1 requires at least 820 bytes, but only 0 remain")
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- reject CompactSize counts or lengths that cannot fit in the remaining parser input before allocating slices
- cover block transaction counts, block header Equihash solution length, transparent inputs and outputs, Sapling v4/v5 spends and outputs, JoinSplits, and Orchard actions
- preserve valid parsing behavior while returning earlier errors for malformed or truncated input

## Testing
- `GOCACHE=/tmp/zcash-lightwalletd-go-build go test ./parser`