### PR TITLE
fix(common,frontend): make RawRequest context-aware for streaming RPC cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The most recent changes are listed first.
 
 ## [Unreleased]
 
+### Fixed
+
+- Make `common.RawRequest` context-aware so cancelled `GetBlockRange` /
+  `GetBlockRangeNullifiers` streams abort in-flight zcashd JSON-RPC calls
+  instead of holding a goroutine and RPC connection until the request
+  completes.
+
 ### Added
 
 - Add debug logging to gRPC entry and exit points.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -215,7 +215,12 @@ func startServer(opts *common.Options) error {
 			}).Fatal("setting up RPC connection to zebrad or zcashd")
 		}
 		// Indirect function for test mocking (so unit tests can talk to stub functions).
-		common.RawRequest = frontend.NewContextRawRequest(connCfg)
+		common.RawRequest, err = frontend.NewContextRawRequest(connCfg)
+		if err != nil {
+			common.Log.WithFields(logrus.Fields{
+				"error": err,
+			}).Fatal("setting up RPC connection to zebrad or zcashd")
+		}
 
 		// Ensure that we can communicate with zcashd
 		common.FirstRPC()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -192,23 +193,29 @@ func startServer(opts *common.Options) error {
 	// of block streamer.
 
 	var chainName string
-	var rpcClient *rpcclient.Client
+	var connCfg *rpcclient.ConnConfig
 	var err error
 	if opts.Darkside {
 		chainName = "darkside"
 	} else {
 		if opts.RPCUser != "" && opts.RPCPassword != "" && opts.RPCHost != "" && opts.RPCPort != "" {
-			rpcClient, err = frontend.NewZRPCFromFlags(opts)
+			connCfg = frontend.ConnConfigFromFlags(opts)
 		} else {
-			rpcClient, err = frontend.NewZRPCFromConf(opts.ZcashConfPath)
+			connCfg, err = frontend.ConnConfigFromConf(opts.ZcashConfPath)
 		}
 		if err != nil {
 			common.Log.WithFields(logrus.Fields{
 				"error": err,
 			}).Fatal("setting up RPC connection to zebrad or zcashd")
 		}
+		_, err = rpcclient.New(connCfg, nil)
+		if err != nil {
+			common.Log.WithFields(logrus.Fields{
+				"error": err,
+			}).Fatal("setting up RPC connection to zebrad or zcashd")
+		}
 		// Indirect function for test mocking (so unit tests can talk to stub functions).
-		common.RawRequest = rpcClient.RawRequest
+		common.RawRequest = frontend.NewContextRawRequest(connCfg)
 
 		// Ensure that we can communicate with zcashd
 		common.FirstRPC()
@@ -238,7 +245,7 @@ func startServer(opts *common.Options) error {
 			common.Log.Info("Detected zebrad backend; skipping experimental feature check")
 
 		case strings.Contains(subver, "/MagicBean:"):
-			result, rpcErr := common.RawRequest("getexperimentalfeatures", []json.RawMessage{})
+			result, rpcErr := common.RawRequest(context.Background(), "getexperimentalfeatures", []json.RawMessage{})
 			if rpcErr != nil {
 				common.Log.Fatalf("zcashd backend detected but getexperimentalfeatures RPC failed: %s", rpcErr.Error())
 			}

--- a/common/common.go
+++ b/common/common.go
@@ -59,9 +59,9 @@ type Options struct {
 }
 
 // RawRequest points to the function to send an RPC request to zcashd;
-// in production, it points to btcsuite/btcd/rpcclient/rawrequest.go:RawRequest();
+// in production, it points to frontend.NewContextRawRequest();
 // in unit tests it points to a function to mock RPCs to zcashd.
-var RawRequest func(method string, params []json.RawMessage) (json.RawMessage, error)
+var RawRequest func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error)
 
 // Time allows time-related functions to be mocked for testing,
 // so that tests can be deterministic and so they don't require
@@ -246,7 +246,7 @@ func FirstRPC() {
 }
 
 func GetBlockChainInfo() (*ZcashdRpcReplyGetblockchaininfo, error) {
-	result, rpcErr := RawRequest("getblockchaininfo", []json.RawMessage{})
+	result, rpcErr := RawRequest(context.Background(), "getblockchaininfo", []json.RawMessage{})
 	if rpcErr != nil {
 		return nil, rpcErr
 	}
@@ -259,7 +259,7 @@ func GetBlockChainInfo() (*ZcashdRpcReplyGetblockchaininfo, error) {
 }
 
 func GetLightdInfo() (*walletrpc.LightdInfo, error) {
-	result, rpcErr := RawRequest("getinfo", []json.RawMessage{})
+	result, rpcErr := RawRequest(context.Background(), "getinfo", []json.RawMessage{})
 	if rpcErr != nil {
 		return nil, rpcErr
 	}
@@ -269,7 +269,7 @@ func GetLightdInfo() (*walletrpc.LightdInfo, error) {
 		return nil, err
 	}
 
-	result, rpcErr = RawRequest("getblockchaininfo", []json.RawMessage{})
+	result, rpcErr = RawRequest(context.Background(), "getblockchaininfo", []json.RawMessage{})
 	if rpcErr != nil {
 		return nil, rpcErr
 	}
@@ -318,7 +318,7 @@ func GetLightdInfo() (*walletrpc.LightdInfo, error) {
 	}, nil
 }
 
-func getBlockFromRPC(height int) (*walletrpc.CompactBlock, error) {
+func getBlockFromRPC(ctx context.Context, height int) (*walletrpc.CompactBlock, error) {
 	// `block.ParseFromSlice` correctly parses blocks containing v5
 	// transactions, but incorrectly computes the IDs of the v5 transactions.
 	// We temporarily paper over this bug by fetching the correct txids via a
@@ -339,7 +339,7 @@ func getBlockFromRPC(height int) (*walletrpc.CompactBlock, error) {
 	// by height in case a reorg occurs between the two getblock calls;
 	// using block hash ensures that we're fetching the same block.
 	params := []json.RawMessage{heightJSON, json.RawMessage("1")}
-	result, rpcErr := RawRequest("getblock", params)
+	result, rpcErr := RawRequest(ctx, "getblock", params)
 	if rpcErr != nil {
 		// Check to see if we are requesting a height the zcashd doesn't have yet
 		if (strings.Split(rpcErr.Error(), ":"))[0] == "-8" {
@@ -356,9 +356,12 @@ func getBlockFromRPC(height int) (*walletrpc.CompactBlock, error) {
 	if err != nil {
 		Log.Fatal("getBlockFromRPC bad block hash", block1.Hash)
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	// non-verbose (raw hex) version of block
 	params = []json.RawMessage{blockHash, json.RawMessage("0")}
-	result, rpcErr = RawRequest("getblock", params)
+	result, rpcErr = RawRequest(ctx, "getblock", params)
 
 	// For some reason, the error responses are not JSON
 	if rpcErr != nil {
@@ -434,7 +437,7 @@ func BlockIngestor(c *BlockCache, rep int) {
 		default:
 		}
 
-		result, err := RawRequest("getbestblockhash", []json.RawMessage{})
+		result, err := RawRequest(context.Background(), "getbestblockhash", []json.RawMessage{})
 		if err != nil {
 			Log.WithFields(logrus.Fields{
 				"error": err,
@@ -463,7 +466,7 @@ func BlockIngestor(c *BlockCache, rep int) {
 			continue
 		}
 		var block *walletrpc.CompactBlock
-		block, err = getBlockFromRPC(height)
+		block, err = getBlockFromRPC(context.Background(), height)
 		if err != nil {
 			Log.Info("getblock ", height, " failed, will retry: ", err)
 			Time.Sleep(8 * time.Second)
@@ -496,7 +499,7 @@ func BlockIngestor(c *BlockCache, rep int) {
 // the cache, then, if not found, will request the block from zcashd. It returns
 // nil if no block exists at this height.
 // This returns gRPC-compatible errors.
-func GetBlock(cache *BlockCache, height int) (*walletrpc.CompactBlock, error) {
+func GetBlock(ctx context.Context, cache *BlockCache, height int) (*walletrpc.CompactBlock, error) {
 	// First, check the cache to see if we have the block
 	var block *walletrpc.CompactBlock
 	if cache != nil {
@@ -507,7 +510,7 @@ func GetBlock(cache *BlockCache, height int) (*walletrpc.CompactBlock, error) {
 	}
 
 	// Not in the cache
-	block, err := getBlockFromRPC(height)
+	block, err := getBlockFromRPC(ctx, height)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument,
 			"GetBlock: getblock failed, error: %s", err.Error())
@@ -599,7 +602,7 @@ func GetBlockRange(ctx context.Context, cache *BlockCache, blockOut chan<- *wall
 			j = high - (i - low)
 		}
 
-		block, err := GetBlock(cache, j)
+		block, err := GetBlock(ctx, cache, j)
 		if err != nil {
 			select {
 			case errOut <- err:

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -101,7 +101,7 @@ func afterStub(d time.Duration) <-chan time.Time {
 
 // ------------------------------------------ GetLightdInfo()
 
-func getLightdInfoStub(method string, params []json.RawMessage) (json.RawMessage, error) {
+func getLightdInfoStub(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
 	step++
 	switch method {
 	case "getinfo":
@@ -225,7 +225,7 @@ func checkSleepMethod(count int, duration time.Duration, expected string, method
 // by just prepending "0000" to X in string form. For example, the "hash" of block 380640
 // is "0000380640". It may be better to make the (fake) hashes 32 bytes (64 characters),
 // and that may be required in the future, but for now this works okay.
-func blockIngestorStub(method string, params []json.RawMessage) (json.RawMessage, error) {
+func blockIngestorStub(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
 	var arg string
 	if len(params) > 1 {
 		err := json.Unmarshal(params[0], &arg)
@@ -416,7 +416,7 @@ func TestBlockIngestor(t *testing.T) {
 
 // There are four test blocks, 0..3
 // (probably don't need all these cases)
-func getblockStub(method string, params []json.RawMessage) (json.RawMessage, error) {
+func getblockStub(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
 	if method != "getblock" {
 		testT.Error("unexpected method")
 	}
@@ -508,8 +508,36 @@ func TestGetBlockRange(t *testing.T) {
 	os.RemoveAll(unitTestPath)
 }
 
+func TestGetBlockRangeCancelsInFlightRPC(t *testing.T) {
+	RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	os.RemoveAll(unitTestPath)
+	testcache = NewBlockCache(unitTestPath, unitTestChain, 380640, 0)
+	ctx, cancel := context.WithCancel(context.Background())
+	blockChan := make(chan *walletrpc.CompactBlock)
+	errChan := make(chan error, 1)
+	blockRange := &walletrpc.BlockRange{
+		Start: &walletrpc.BlockID{Height: 380640},
+		End:   &walletrpc.BlockID{Height: 380640},
+	}
+	done := make(chan struct{})
+	go func() {
+		GetBlockRange(ctx, testcache, blockChan, errChan, blockRange)
+		close(done)
+	}()
+	cancel()
+	select {
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetBlockRange did not exit after context cancellation")
+	case <-done:
+	}
+	os.RemoveAll(unitTestPath)
+}
+
 // There are four test blocks, 0..3
-func getblockStubReverse(method string, params []json.RawMessage) (json.RawMessage, error) {
+func getblockStubReverse(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
 	var arg string
 	err := json.Unmarshal(params[0], &arg)
 	if err != nil {
@@ -621,7 +649,7 @@ func TestGenerateCerts(t *testing.T) {
 // Note that in mocking zcashd's RPC replies here, we don't really need
 // actual txids or transactions, or even strings with the correct format
 // for those, except that a transaction must be a hex string.
-func mempoolStub(method string, params []json.RawMessage) (json.RawMessage, error) {
+func mempoolStub(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
 	step++
 	switch step {
 	case 1:
@@ -839,7 +867,7 @@ func TestMempoolStreamCancelOnEmptyMempool(t *testing.T) {
 	// Stub RawRequest to return a stable empty-mempool / stable-tip world,
 	// so the loop parks at the cancel-aware sleep with no work and no tip
 	// change to break out.
-	RawRequest = func(method string, params []json.RawMessage) (json.RawMessage, error) {
+	RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
 		switch method {
 		case "getblockchaininfo":
 			r, _ := json.Marshal(&ZcashdRpcReplyGetblockchaininfo{

--- a/common/darkside.go
+++ b/common/darkside.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"bufio"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -135,7 +136,12 @@ func DarksideInit(c *BlockCache, timeout int) {
 	Log.Info("Darkside mode running")
 	DarksideEnabled = true
 	state.cache = c
-	RawRequest = darksideRawRequest
+	RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		return darksideRawRequest(method, params)
+	}
 	go func() {
 		time.Sleep(time.Duration(timeout) * time.Minute)
 		Log.Fatal("Shutting down darksidewalletd to prevent accidental deployment in production.")

--- a/common/mempool.go
+++ b/common/mempool.go
@@ -68,7 +68,7 @@ func GetMempool(ctx context.Context, sendToClient func(*walletrpc.RawTransaction
 				g_lastTime = time.Time{}
 				break
 			}
-			if err = refreshMempoolTxns(); err != nil {
+			if err = refreshMempoolTxns(ctx); err != nil {
 				g_lock.Unlock()
 				return err
 			}
@@ -102,9 +102,9 @@ func GetMempool(ctx context.Context, sendToClient func(*walletrpc.RawTransaction
 }
 
 // RefreshMempoolTxns gets all new mempool txns and sends any new ones to waiting clients
-func refreshMempoolTxns() error {
+func refreshMempoolTxns(ctx context.Context) error {
 	params := []json.RawMessage{}
-	result, rpcErr := RawRequest("getrawmempool", params)
+	result, rpcErr := RawRequest(ctx, "getrawmempool", params)
 	if rpcErr != nil {
 		return rpcErr
 	}
@@ -129,7 +129,7 @@ func refreshMempoolTxns() error {
 		}
 
 		params := []json.RawMessage{txidJSON, json.RawMessage("1")}
-		result, rpcErr := RawRequest("getrawtransaction", params)
+		result, rpcErr := RawRequest(ctx, "getrawtransaction", params)
 		if rpcErr != nil {
 			// Not an error; mempool transactions can disappear
 			continue

--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -138,7 +138,7 @@ func TestGetTransaction(t *testing.T) {
 	}
 }
 
-func getLatestBlockStub(method string, params []json.RawMessage) (json.RawMessage, error) {
+func getLatestBlockStub(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
 	step++
 
 	// Test retry logic (for the moment, it's very simple, just one retry).
@@ -194,7 +194,7 @@ func TestGetLatestBlock(t *testing.T) {
 	req := &walletrpc.ChainSpec{}
 
 	// This does zcashd rpc "getblock", calls getLatestBlockStub() above
-	block, err := common.GetBlock(cache, 380640)
+	block, err := common.GetBlock(context.Background(), cache, 380640)
 	if err != nil {
 		t.Fatal("getBlockFromRPC failed", err)
 	}
@@ -229,7 +229,7 @@ var addressTests = []string{
 	"t1234567890123456789012345678901234\n", // newline after
 }
 
-func zcashdrpcStub(method string, params []json.RawMessage) (json.RawMessage, error) {
+func zcashdrpcStub(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
 	step++
 	switch method {
 	case "getaddresstxids":
@@ -363,7 +363,7 @@ func TestGetTaddressTransactionsNilArgs(t *testing.T) {
 	}
 }
 
-func getblockStub(method string, params []json.RawMessage) (json.RawMessage, error) {
+func getblockStub(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
 	if method != "getblock" {
 		testT.Fatal("unexpected method:", method)
 	}
@@ -494,7 +494,7 @@ func TestGetBlockRangeNilArgs(t *testing.T) {
 	}
 }
 
-func sendrawtransactionStub(method string, params []json.RawMessage) (json.RawMessage, error) {
+func sendrawtransactionStub(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
 	step++
 	if method != "sendrawtransaction" {
 		testT.Fatal("unexpected method")

--- a/frontend/rawrequest.go
+++ b/frontend/rawrequest.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2019-2020 The Zcash developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+package frontend
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/rpcclient"
+)
+
+const (
+	requestRetryInterval = 500 * time.Millisecond
+	defaultHTTPTimeout   = time.Minute
+)
+
+type jsonRPCResponse struct {
+	Result json.RawMessage   `json:"result"`
+	Error  *btcjson.RPCError `json:"error"`
+}
+
+func rpcHTTPURL(cfg *rpcclient.ConnConfig) string {
+	protocol := "http"
+	if !cfg.DisableTLS {
+		protocol = "https"
+	}
+	return protocol + "://" + cfg.Host
+}
+
+// NewContextRawRequest returns a context-aware JSON-RPC function for zcashd and
+// zebrad. HTTP POST requests honour ctx cancellation via http.NewRequestWithContext.
+// When btcd's rpcclient exposes RawRequestWithContext, this wrapper can delegate
+// to it instead of issuing requests directly.
+func NewContextRawRequest(cfg *rpcclient.ConnConfig) func(context.Context, string, []json.RawMessage) (json.RawMessage, error) {
+	httpClient := &http.Client{Timeout: defaultHTTPTimeout}
+	httpURL := rpcHTTPURL(cfg)
+
+	return func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
+		if method == "" {
+			return nil, errors.New("no method")
+		}
+		if params == nil {
+			params = []json.RawMessage{}
+		}
+		if ctx == nil {
+			ctx = context.Background()
+		}
+
+		reqBody, err := json.Marshal(&btcjson.Request{
+			Jsonrpc: btcjson.RpcVersion1,
+			ID:      1,
+			Method:  method,
+			Params:  params,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		tries := 10
+		var lastErr error
+		for i := 0; i < tries; i++ {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+
+			httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, httpURL, bytes.NewReader(reqBody))
+			if err != nil {
+				return nil, err
+			}
+			httpReq.Close = true
+			httpReq.Header.Set("Content-Type", "application/json")
+			for key, value := range cfg.ExtraHeaders {
+				httpReq.Header.Set(key, value)
+			}
+			httpReq.SetBasicAuth(cfg.User, cfg.Pass)
+
+			httpResp, err := httpClient.Do(httpReq)
+			if err != nil {
+				if ctx.Err() != nil {
+					return nil, ctx.Err()
+				}
+				if i == tries-1 {
+					return nil, err
+				}
+				lastErr = err
+				backoff := requestRetryInterval * time.Duration(i+1)
+				if backoff > time.Minute {
+					backoff = time.Minute
+				}
+				select {
+				case <-time.After(backoff):
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+				continue
+			}
+			respBytes, readErr := io.ReadAll(httpResp.Body)
+			httpResp.Body.Close()
+			if readErr != nil {
+				return nil, fmt.Errorf("error reading json reply: %w", readErr)
+			}
+			var resp jsonRPCResponse
+			if err := json.Unmarshal(respBytes, &resp); err != nil {
+				return nil, fmt.Errorf("status code: %d, response: %q",
+					httpResp.StatusCode, string(respBytes))
+			}
+			if resp.Error != nil {
+				return nil, resp.Error
+			}
+			return resp.Result, nil
+		}
+		return nil, fmt.Errorf("invalid http POST response after retries, method: %s, last error=%v",
+			method, lastErr)
+	}
+}

--- a/frontend/rawrequest.go
+++ b/frontend/rawrequest.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 The Zcash developers
+// Copyright (c) 2026 The Zcash developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php .
 

--- a/frontend/rawrequest.go
+++ b/frontend/rawrequest.go
@@ -7,11 +7,14 @@ package frontend
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/btcsuite/btcd/btcjson"
@@ -36,12 +39,51 @@ func rpcHTTPURL(cfg *rpcclient.ConnConfig) string {
 	return protocol + "://" + cfg.Host
 }
 
+// newContextHTTPClient builds an HTTP client that honours the proxy and TLS
+// settings on cfg, mirroring btcsuite/btcd/rpcclient's newHTTPClient. This keeps
+// NewContextRawRequest a faithful drop-in for rpcclient.RawRequest rather than
+// silently dropping proxy or custom-CA configuration when TLS is enabled.
+func newContextHTTPClient(cfg *rpcclient.ConnConfig) (*http.Client, error) {
+	var proxyFunc func(*http.Request) (*url.URL, error)
+	if cfg.Proxy != "" {
+		proxyURL, err := url.Parse(cfg.Proxy)
+		if err != nil {
+			return nil, err
+		}
+		proxyFunc = http.ProxyURL(proxyURL)
+	}
+
+	var tlsConfig *tls.Config
+	if !cfg.DisableTLS && len(cfg.Certificates) > 0 {
+		pool := x509.NewCertPool()
+		pool.AppendCertsFromPEM(cfg.Certificates)
+		tlsConfig = &tls.Config{RootCAs: pool}
+	}
+
+	return &http.Client{
+		Timeout: defaultHTTPTimeout,
+		Transport: &http.Transport{
+			Proxy:           proxyFunc,
+			TLSClientConfig: tlsConfig,
+		},
+	}, nil
+}
+
 // NewContextRawRequest returns a context-aware JSON-RPC function for zcashd and
-// zebrad. HTTP POST requests honour ctx cancellation via http.NewRequestWithContext.
-// When btcd's rpcclient exposes RawRequestWithContext, this wrapper can delegate
-// to it instead of issuing requests directly.
-func NewContextRawRequest(cfg *rpcclient.ConnConfig) func(context.Context, string, []json.RawMessage) (json.RawMessage, error) {
-	httpClient := &http.Client{Timeout: defaultHTTPTimeout}
+// zebrad. It is a port of btcsuite/btcd/rpcclient's HTTP POST path (same retry
+// count, backoff schedule, and per-request connection handling) with ctx threaded
+// through via http.NewRequestWithContext, so that a cancelled gRPC stream aborts
+// the in-flight request instead of leaking a goroutine and a zcashd RPC slot.
+//
+// This wrapper exists only because btcd's rpcclient does not yet expose a
+// context-aware request method. Once btcsuite/btcd#2506 (RawRequestWithContext)
+// is merged and released, bump the btcd dependency and replace this with a direct
+// delegation to it: https://github.com/btcsuite/btcd/pull/2506
+func NewContextRawRequest(cfg *rpcclient.ConnConfig) (func(context.Context, string, []json.RawMessage) (json.RawMessage, error), error) {
+	httpClient, err := newContextHTTPClient(cfg)
+	if err != nil {
+		return nil, err
+	}
 	httpURL := rpcHTTPURL(cfg)
 
 	return func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
@@ -120,5 +162,5 @@ func NewContextRawRequest(cfg *rpcclient.ConnConfig) func(context.Context, strin
 		}
 		return nil, fmt.Errorf("invalid http POST response after retries, method: %s, last error=%v",
 			method, lastErr)
-	}
+	}, nil
 }

--- a/frontend/rawrequest_test.go
+++ b/frontend/rawrequest_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2019-2020 The Zcash developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+package frontend
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/btcsuite/btcd/rpcclient"
+)
+
+func TestContextRawRequestSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		if string(body) == "" {
+			t.Error("empty request body")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"result":"ok","error":null}`))
+	}))
+	defer server.Close()
+
+	cfg := &rpcclient.ConnConfig{
+		Host:         server.Listener.Addr().String(),
+		User:         "user",
+		Pass:         "pass",
+		HTTPPostMode: true,
+		DisableTLS:   true,
+	}
+	rawRequest := NewContextRawRequest(cfg)
+
+	result, err := rawRequest(context.Background(), "getblockchaininfo", nil)
+	if err != nil {
+		t.Fatalf("RawRequest failed: %v", err)
+	}
+	var reply string
+	if err := json.Unmarshal(result, &reply); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if reply != "ok" {
+		t.Fatalf("unexpected result %q", reply)
+	}
+}

--- a/frontend/rawrequest_test.go
+++ b/frontend/rawrequest_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 The Zcash developers
+// Copyright (c) 2026 The Zcash developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php .
 

--- a/frontend/rawrequest_test.go
+++ b/frontend/rawrequest_test.go
@@ -7,10 +7,13 @@ package frontend
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/rpcclient"
 )
@@ -36,7 +39,10 @@ func TestContextRawRequestSuccess(t *testing.T) {
 		HTTPPostMode: true,
 		DisableTLS:   true,
 	}
-	rawRequest := NewContextRawRequest(cfg)
+	rawRequest, err := NewContextRawRequest(cfg)
+	if err != nil {
+		t.Fatalf("NewContextRawRequest failed: %v", err)
+	}
 
 	result, err := rawRequest(context.Background(), "getblockchaininfo", nil)
 	if err != nil {
@@ -48,5 +54,61 @@ func TestContextRawRequestSuccess(t *testing.T) {
 	}
 	if reply != "ok" {
 		t.Fatalf("unexpected result %q", reply)
+	}
+}
+
+// TestContextRawRequestCancel verifies that cancelling the context aborts an
+// in-flight request promptly, rather than blocking until the zcashd RPC returns.
+// This is the core guarantee of the fix for GHSA-5h96-xw2v-jxgq.
+func TestContextRawRequestCancel(t *testing.T) {
+	var once sync.Once
+	started := make(chan struct{})
+	// release lets us unblock the handler at teardown so server.Close() does not
+	// hang: a client-side context cancel aborts the request but does not
+	// necessarily fire the server's r.Context().Done() promptly.
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		once.Do(func() { close(started) })
+		select {
+		case <-r.Context().Done():
+		case <-release:
+		}
+	}))
+	defer server.Close()
+	defer close(release)
+
+	cfg := &rpcclient.ConnConfig{
+		Host:         server.Listener.Addr().String(),
+		User:         "user",
+		Pass:         "pass",
+		HTTPPostMode: true,
+		DisableTLS:   true,
+	}
+	rawRequest, err := NewContextRawRequest(cfg)
+	if err != nil {
+		t.Fatalf("NewContextRawRequest failed: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := rawRequest(ctx, "getblockchaininfo", nil)
+		errCh <- err
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("request never reached the server")
+	}
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("rawRequest did not return promptly after cancellation")
 	}
 }

--- a/frontend/rpc_client.go
+++ b/frontend/rpc_client.go
@@ -16,9 +16,25 @@ import (
 	ini "gopkg.in/ini.v1"
 )
 
+// ConnConfigFromConf reads the zcashd configuration file.
+func ConnConfigFromConf(confPath string) (*rpcclient.ConnConfig, error) {
+	return connFromConf(confPath)
+}
+
+// ConnConfigFromFlags builds an RPC connection config from provided flags.
+func ConnConfigFromFlags(opts *common.Options) *rpcclient.ConnConfig {
+	return &rpcclient.ConnConfig{
+		Host:         net.JoinHostPort(opts.RPCHost, opts.RPCPort),
+		User:         opts.RPCUser,
+		Pass:         opts.RPCPassword,
+		HTTPPostMode: true, // Zcash only supports HTTP POST mode
+		DisableTLS:   true, // Zcash does not provide TLS by default
+	}
+}
+
 // NewZRPCFromConf reads the zcashd configuration file.
 func NewZRPCFromConf(confPath string) (*rpcclient.Client, error) {
-	connCfg, err := connFromConf(confPath)
+	connCfg, err := ConnConfigFromConf(confPath)
 	if err != nil {
 		return nil, err
 	}
@@ -27,15 +43,7 @@ func NewZRPCFromConf(confPath string) (*rpcclient.Client, error) {
 
 // NewZRPCFromFlags gets zcashd rpc connection information from provided flags.
 func NewZRPCFromFlags(opts *common.Options) (*rpcclient.Client, error) {
-	// Connect to local Zcash RPC server using HTTP POST mode.
-	connCfg := &rpcclient.ConnConfig{
-		Host:         net.JoinHostPort(opts.RPCHost, opts.RPCPort),
-		User:         opts.RPCUser,
-		Pass:         opts.RPCPassword,
-		HTTPPostMode: true, // Zcash only supports HTTP POST mode
-		DisableTLS:   true, // Zcash does not provide TLS by default
-	}
-	return rpcclient.New(connCfg, nil)
+	return rpcclient.New(ConnConfigFromFlags(opts), nil)
 }
 
 func connFromConf(confPath string) (*rpcclient.ConnConfig, error) {

--- a/frontend/service.go
+++ b/frontend/service.go
@@ -121,7 +121,7 @@ func (s *lwdStreamer) GetTaddressTransactions(addressBlockFilter *walletrpc.Tran
 	}
 	params := []json.RawMessage{param}
 
-	result, rpcErr := common.RawRequest("getaddresstxids", params)
+	result, rpcErr := common.RawRequest(resp.Context(), "getaddresstxids", params)
 
 	// For some reason, the error responses are not JSON
 	if rpcErr != nil {
@@ -179,7 +179,7 @@ func (s *lwdStreamer) GetBlock(ctx context.Context, id *walletrpc.BlockID) (*wal
 		return nil, status.Error(codes.InvalidArgument,
 			"GetBlock: Block hash specifier is not yet implemented")
 	}
-	cBlock, err := common.GetBlock(s.cache, int(id.Height))
+	cBlock, err := common.GetBlock(ctx, s.cache, int(id.Height))
 
 	if err != nil {
 		return nil, err
@@ -204,7 +204,7 @@ func (s *lwdStreamer) GetBlockNullifiers(ctx context.Context, id *walletrpc.Bloc
 		return nil, status.Error(codes.InvalidArgument,
 			"GetBlockNullifiers: GetBlock by Hash is not yet implemented")
 	}
-	cBlock, err := common.GetBlock(s.cache, int(id.Height))
+	cBlock, err := common.GetBlock(ctx, s.cache, int(id.Height))
 	if err != nil {
 		// GetBlock() returns gRPC-compatible errors.
 		return nil, err
@@ -346,7 +346,7 @@ func (s *lwdStreamer) GetTreeState(ctx context.Context, id *walletrpc.BlockID) (
 		if err := ctx.Err(); err != nil {
 			return nil, status.FromContextError(err).Err()
 		}
-		result, rpcErr := common.RawRequest("z_gettreestate", params)
+		result, rpcErr := common.RawRequest(ctx, "z_gettreestate", params)
 		if rpcErr != nil {
 			return nil, status.Errorf(codes.InvalidArgument,
 				"GetTreeState: z_gettreestate failed: %s", rpcErr.Error())
@@ -418,7 +418,7 @@ func (s *lwdStreamer) GetTransaction(ctx context.Context, txf *walletrpc.TxFilte
 		}
 
 		params := []json.RawMessage{txidJSON, json.RawMessage("1")}
-		result, rpcErr := common.RawRequest("getrawtransaction", params)
+		result, rpcErr := common.RawRequest(ctx, "getrawtransaction", params)
 		if rpcErr != nil {
 			// For some reason, the error responses are not JSON
 			return nil, status.Errorf(codes.NotFound,
@@ -473,7 +473,7 @@ func (s *lwdStreamer) SendTransaction(ctx context.Context, rawtx *walletrpc.RawT
 		return nil, status.Errorf(codes.InvalidArgument, "cannot marshal tx: %s", err.Error())
 	}
 	params[0] = txJSON
-	result, rpcErr := common.RawRequest("sendrawtransaction", params)
+	result, rpcErr := common.RawRequest(ctx, "sendrawtransaction", params)
 
 	var errCode int64
 	var errMsg string
@@ -508,7 +508,7 @@ func (s *lwdStreamer) SendTransaction(ctx context.Context, rawtx *walletrpc.RawT
 	return r, nil
 }
 
-func getTaddressBalanceZcashdRpc(addressList []string) (*walletrpc.Balance, error) {
+func getTaddressBalanceZcashdRpc(ctx context.Context, addressList []string) (*walletrpc.Balance, error) {
 	for _, addr := range addressList {
 		if err := checkTaddress(addr); err != nil {
 			return nil, err
@@ -524,7 +524,7 @@ func getTaddressBalanceZcashdRpc(addressList []string) (*walletrpc.Balance, erro
 	}
 	params[0] = param
 
-	result, rpcErr := common.RawRequest("getaddressbalance", params)
+	result, rpcErr := common.RawRequest(ctx, "getaddressbalance", params)
 	if rpcErr != nil {
 		var code codes.Code
 		switch {
@@ -548,7 +548,7 @@ func getTaddressBalanceZcashdRpc(addressList []string) (*walletrpc.Balance, erro
 // GetTaddressBalance returns the total balance for a list of taddrs
 func (s *lwdStreamer) GetTaddressBalance(ctx context.Context, addresses *walletrpc.AddressList) (*walletrpc.Balance, error) {
 	common.Log.Debugf("gRPC GetTaddressBalance(%+v)\n", addresses)
-	r, err := getTaddressBalanceZcashdRpc(addresses.Addresses)
+	r, err := getTaddressBalanceZcashdRpc(ctx, addresses.Addresses)
 	if err == nil {
 		common.Log.Tracef("  return: %+v\n", r)
 	}
@@ -569,7 +569,7 @@ func (s *lwdStreamer) GetTaddressBalanceStream(addresses walletrpc.CompactTxStre
 		}
 		addressList = append(addressList, addr.Address)
 	}
-	balance, err := getTaddressBalanceZcashdRpc(addressList)
+	balance, err := getTaddressBalanceZcashdRpc(addresses.Context(), addressList)
 	if err != nil {
 		return err
 	}
@@ -617,11 +617,12 @@ func (s *lwdStreamer) GetMempoolTx(exclude *walletrpc.GetMempoolTxRequest, resp 
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
+	streamCtx := resp.Context()
 	if time.Since(lastMempool).Seconds() >= 2 {
 		lastMempool = time.Now()
 		// Refresh our copy of the mempool.
 		params := make([]json.RawMessage, 0)
-		result, rpcErr := common.RawRequest("getrawmempool", params)
+		result, rpcErr := common.RawRequest(streamCtx, "getrawmempool", params)
 		if rpcErr != nil {
 			return status.Errorf(codes.Internal, "GetMempoolTx: getrawmempool error: %s", rpcErr.Error())
 		}
@@ -648,7 +649,7 @@ func (s *lwdStreamer) GetMempoolTx(exclude *walletrpc.GetMempoolTxRequest, resp 
 			// The "0" is because we only need the raw hex, which is returned as
 			// just a hex string, and not even a json string (with quotes).
 			params := []json.RawMessage{txidJSON, json.RawMessage("0")}
-			result, rpcErr := common.RawRequest("getrawtransaction", params)
+			result, rpcErr := common.RawRequest(streamCtx, "getrawtransaction", params)
 			if rpcErr != nil {
 				// Not an error; mempool transactions can disappear
 				continue
@@ -746,7 +747,7 @@ func MempoolFilter(items, exclude []string) []string {
 	return tosend
 }
 
-func getAddressUtxos(arg *walletrpc.GetAddressUtxosArg, f func(*walletrpc.GetAddressUtxosReply) error) error {
+func getAddressUtxos(ctx context.Context, arg *walletrpc.GetAddressUtxosArg, f func(*walletrpc.GetAddressUtxosReply) error) error {
 	for _, a := range arg.Addresses {
 		if err := checkTaddress(a); err != nil {
 			return err
@@ -761,7 +762,7 @@ func getAddressUtxos(arg *walletrpc.GetAddressUtxosArg, f func(*walletrpc.GetAdd
 			"getAddressUtxos: failed to marshal addrList, error: %s", err.Error())
 	}
 	params := []json.RawMessage{param}
-	result, rpcErr := common.RawRequest("getaddressutxos", params)
+	result, rpcErr := common.RawRequest(ctx, "getaddressutxos", params)
 	if rpcErr != nil {
 		var code codes.Code
 		switch {
@@ -817,7 +818,7 @@ func getAddressUtxos(arg *walletrpc.GetAddressUtxosArg, f func(*walletrpc.GetAdd
 func (s *lwdStreamer) GetAddressUtxos(ctx context.Context, arg *walletrpc.GetAddressUtxosArg) (*walletrpc.GetAddressUtxosReplyList, error) {
 	common.Log.Debugf("gRPC GetAddressUtxos(%+v)\n", arg)
 	addressUtxos := make([]*walletrpc.GetAddressUtxosReply, 0)
-	err := getAddressUtxos(arg, func(utxo *walletrpc.GetAddressUtxosReply) error {
+	err := getAddressUtxos(ctx, arg, func(utxo *walletrpc.GetAddressUtxosReply) error {
 		addressUtxos = append(addressUtxos, utxo)
 		return nil
 	})
@@ -863,7 +864,7 @@ func (s *lwdStreamer) GetSubtreeRoots(arg *walletrpc.GetSubtreeRootsArg, resp wa
 		}
 		params = append(params, maxEntriesJSON)
 	}
-	result, rpcErr := common.RawRequest("z_getsubtreesbyindex", params)
+	result, rpcErr := common.RawRequest(resp.Context(), "z_getsubtreesbyindex", params)
 	if rpcErr != nil {
 		return status.Errorf(codes.InvalidArgument,
 			"GetSubtreeRoots: z_getsubtreesbyindex, error: %s", rpcErr.Error())
@@ -875,15 +876,11 @@ func (s *lwdStreamer) GetSubtreeRoots(arg *walletrpc.GetSubtreeRootsArg, resp wa
 			"GetSubtreeRoots: failed to unmarshal z_getsubtreesbyindex reply, error: %s", err.Error())
 	}
 	for i := 0; i < len(reply.Subtrees); i++ {
-		// Observe client cancel between per-subtree GetBlock calls. Each cache
-		// miss issues two zcashd RPCs (getblock by hash + by height) that are
-		// not ctx-aware via common.RawRequest; this check ensures a cancelling
-		// client doesn't keep zcashd busy on a long subtree range.
 		if err := resp.Context().Err(); err != nil {
 			return status.FromContextError(err).Err()
 		}
 		subtree := reply.Subtrees[i]
-		block, err := common.GetBlock(s.cache, subtree.End_height)
+		block, err := common.GetBlock(resp.Context(), s.cache, subtree.End_height)
 		if block == nil {
 			// It may be worth trying to determine a more specific error code
 			return status.Error(codes.Internal, err.Error())
@@ -908,7 +905,7 @@ func (s *lwdStreamer) GetSubtreeRoots(arg *walletrpc.GetSubtreeRootsArg, resp wa
 
 func (s *lwdStreamer) GetAddressUtxosStream(arg *walletrpc.GetAddressUtxosArg, resp walletrpc.CompactTxStreamer_GetAddressUtxosStreamServer) error {
 	common.Log.Debugf("gRPC GetAddressUtxosStream(%+v)\n", arg)
-	err := getAddressUtxos(arg, func(utxo *walletrpc.GetAddressUtxosReply) error {
+	err := getAddressUtxos(resp.Context(), arg, func(utxo *walletrpc.GetAddressUtxosReply) error {
 		return resp.Send(utxo)
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

Addresses the residual goroutine/RPC-slot leak described in [GHSA-5h96-xw2v-jxgq](https://github.com/zcash/lightwalletd/security/advisories/GHSA-5h96-xw2v-jxgq) after PR #560.

PR #560 fixed the unbounded channel-send leak when a gRPC client disconnects mid-stream, but the producer could still remain blocked inside `getBlockFromRPC` → `RawRequest` for the duration of an in-flight zcashd JSON-RPC call. This change propagates `context.Context` through the full RPC path so cancelled streams abort in-flight HTTP requests promptly.

- Change `common.RawRequest` to accept `context.Context` as its first parameter.
- Thread `ctx` through `getBlockFromRPC`, `GetBlock`, and `GetBlockRange` (and gRPC handlers that call them).
- Add `frontend.NewContextRawRequest`, a context-aware HTTP POST JSON-RPC client using `http.NewRequestWithContext`. Production wiring replaces the previous `rpcClient.RawRequest` assignment. When btcd lands `RawRequestWithContext` ([btcsuite/btcd#2506](https://github.com/btcsuite/btcd/pull/2506)), this wrapper can delegate to it directly.
- Return immediately on `ctx.Err()` after `http.Client.Do` errors instead of retrying.