### PR TITLE
Parallel block ingest with connection-pooled RPC client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The most recent changes are listed first.
 
+## [Unreleased]
+
+### Changed
+
+- Speed up initial sync by fetching blocks concurrently during bulk catch-up
+  instead of one at a time, committing them to the cache in strict height
+  order. Worker count and window size are configurable via
+  `LWD_INGEST_WORKERS` (default 8) and `LWD_INGEST_WINDOW` (default 64). The
+  tip is now refreshed only once the last known tip is reached, rather than
+  once per block.
+
+- Reuse pooled keep-alive connections for backend JSON-RPC calls instead of
+  closing the connection after every request, so the concurrent block
+  ingestor is bounded by the backend's throughput rather than by connection
+  setup. Pool size is derived from the ingest worker count and can be
+  overridden with `LWD_RPC_POOL`.
+
 ## [0.5.1] - 2026-07-27
 
 ### Added

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -37,6 +38,22 @@ import (
 
 var cfgFile string
 var logger = logrus.New()
+
+// ingestRPCPoolSize returns the max number of pooled HTTP connections to the
+// backend RPC. It defaults to the ingest worker count (LWD_INGEST_WORKERS, 8)
+// plus headroom for concurrent frontend gRPC traffic, and can be overridden
+// directly with LWD_RPC_POOL.
+func ingestRPCPoolSize() int {
+	workers := 8
+	if v, err := strconv.Atoi(os.Getenv("LWD_INGEST_WORKERS")); err == nil && v > 0 {
+		workers = v
+	}
+	pool := workers + 16
+	if v, err := strconv.Atoi(os.Getenv("LWD_RPC_POOL")); err == nil && v > 0 {
+		pool = v
+	}
+	return pool
+}
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -216,7 +233,10 @@ func startServer(opts *common.Options) error {
 			}).Fatal("setting up RPC connection to zebrad or zcashd")
 		}
 		// Indirect function for test mocking (so unit tests can talk to stub functions).
-		common.RawRequest, err = frontend.NewContextRawRequest(connCfg)
+		// The connection pool is sized to track ingest concurrency with headroom
+		// for frontend gRPC traffic, so the parallel block ingestor's workers
+		// reuse keep-alive connections instead of opening one per request.
+		common.RawRequest, err = frontend.NewContextRawRequest(connCfg, ingestRPCPoolSize())
 		if err != nil {
 			common.Log.WithFields(logrus.Fields{
 				"error": err,

--- a/common/common.go
+++ b/common/common.go
@@ -10,9 +10,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -435,7 +437,159 @@ func stopIngestor() {
 
 // BlockIngestor runs as a goroutine and polls zcashd for new blocks, adding them
 // to the cache. The repetition count, rep, is nonzero only for unit-testing.
+//
+// zr7: in production (rep == 0, non-darkside) it uses a parallel prefetch path
+// (blockIngestorParallel) that fetches a window of blocks concurrently and
+// commits them to the cache in strict height order. During bulk catch-up this
+// saturates the backend instead of being bottlenecked on serial per-block RPC
+// latency. Unit tests and darkside mode require deterministic, single-threaded
+// RPC ordering, so they keep the original serial path (blockIngestorSerial).
 func BlockIngestor(c *BlockCache, rep int) {
+	if rep != 0 || DarksideEnabled {
+		blockIngestorSerial(c, rep)
+		return
+	}
+	blockIngestorParallel(c)
+}
+
+// ingestWindow is how many blocks ahead of the commit point we prefetch, and
+// ingestWorkers is the max number of concurrent getblock RPCs. Both are tunable
+// at runtime via env vars so fetch concurrency can be adjusted without a rebuild.
+func ingestWindow() int {
+	if v, err := strconv.Atoi(os.Getenv("LWD_INGEST_WINDOW")); err == nil && v > 0 {
+		return v
+	}
+	return 64
+}
+
+func ingestWorkers() int {
+	if v, err := strconv.Atoi(os.Getenv("LWD_INGEST_WORKERS")); err == nil && v > 0 {
+		return v
+	}
+	return 8
+}
+
+// blockIngestorParallel fetches blocks [next, next+batch) concurrently and
+// commits them to the cache in strict height order. The cache requires in-order
+// Add(), so only the (latency-dominated) fetch+parse is parallelized; the commit
+// stays sequential and performs the same prev-hash chain / reorg checks as the
+// serial path. (#1)
+//
+// It also stops polling the backend's tip on every block: the tip height is
+// refreshed only once we've caught up to the last known tip, eliminating one RPC
+// round-trip per block during bulk sync. (#2)
+func blockIngestorParallel(c *BlockCache) {
+	lastLog := Time.Now()
+	lastHeightLogged := 0
+	window := ingestWindow()
+	workers := ingestWorkers()
+	if workers > window {
+		workers = window
+	}
+	Log.Info("block ingestor: parallel prefetch enabled (workers=", workers, ", window=", window, ")")
+
+	tipHeight := -1 // last known backend tip height; -1 forces a refresh
+
+	for {
+		// stop if requested
+		select {
+		case <-stopIngestorChan:
+			return
+		default:
+		}
+
+		next := c.GetNextHeight()
+
+		// (#2) Only ask the backend for its tip when we've reached the last
+		// known tip. During bulk catch-up this avoids an RPC per block.
+		if next > tipHeight {
+			ci, err := GetBlockChainInfo()
+			if err != nil {
+				Log.WithFields(logrus.Fields{
+					"error": err,
+				}).Warn("error " + NodeName + " getblockchaininfo rpc, will retry")
+				Time.Sleep(8 * time.Second)
+				continue
+			}
+			tipHeight = int(ci.Blocks)
+		}
+
+		if next > tipHeight {
+			// Caught up; nothing new. Mirror the serial path's behaviour.
+			c.Sync()
+			if lastHeightLogged != next-1 {
+				lastHeightLogged = next - 1
+				Log.Info("Waiting for block: ", next)
+			}
+			Time.Sleep(2 * time.Second)
+			continue
+		}
+
+		// (#1) Fetch [next, next+batch) concurrently.
+		batch := tipHeight - next + 1
+		if batch > window {
+			batch = window
+		}
+		blocks := make([]*walletrpc.CompactBlock, batch)
+		errs := make([]error, batch)
+		sem := make(chan struct{}, workers)
+		var wg sync.WaitGroup
+		for j := 0; j < batch; j++ {
+			wg.Add(1)
+			sem <- struct{}{}
+			go func(j int) {
+				defer wg.Done()
+				defer func() { <-sem }()
+				blocks[j], errs[j] = getBlockFromRPC(context.Background(), next+j)
+			}(j)
+		}
+		wg.Wait()
+
+		// Commit in strict height order. Any error, missing block, or chain
+		// mismatch stops this batch; the outer loop re-evaluates from the
+		// (possibly rewound) nextBlock and re-fetches as needed.
+		for j := 0; j < batch; j++ {
+			height := next + j
+			if errs[j] != nil {
+				Log.Info("getblock ", height, " failed, will retry: ", errs[j])
+				Time.Sleep(8 * time.Second)
+				break
+			}
+			block := blocks[j]
+			if block == nil {
+				// Backend doesn't have this height yet (e.g. a reorg shrank the
+				// chain since we read the tip). Force a tip refresh and retry.
+				tipHeight = -1
+				break
+			}
+			if !c.HashMatch(hash32.T(block.PrevHash)) {
+				if height == c.GetFirstHeight() {
+					c.Sync()
+					Log.Info("Waiting for "+NodeName+" height to reach Sapling activation height ",
+						"(", c.GetFirstHeight(), ")...")
+					Time.Sleep(120 * time.Second)
+					break
+				}
+				Log.Info("REORG: dropping block ", height-1, " ", displayHash(c.GetLatestHash()))
+				c.Reorg(height - 1)
+				break
+			}
+			if err := c.Add(height, block); err != nil {
+				Log.Fatal("Cache add failed:", err)
+			}
+			// Don't log these too often.
+			if Time.Now().Sub(lastLog).Seconds() >= 4 {
+				lastLog = Time.Now()
+				Log.Info("Adding block to cache ", height, " ", displayHash(hash32.T(block.Hash)))
+			}
+		}
+	}
+}
+
+// blockIngestorSerial is the original one-block-at-a-time ingestor, preserved
+// verbatim for unit tests (rep != 0) and darkside mode, which depend on
+// deterministic single-threaded RPC ordering.
+func blockIngestorSerial(c *BlockCache, rep int) {
 	lastLog := Time.Now()
 	lastHeightLogged := 0
 

--- a/frontend/rawrequest.go
+++ b/frontend/rawrequest.go
@@ -43,7 +43,12 @@ func rpcHTTPURL(cfg *rpcclient.ConnConfig) string {
 // settings on cfg, mirroring btcsuite/btcd/rpcclient's newHTTPClient. This keeps
 // NewContextRawRequest a faithful drop-in for rpcclient.RawRequest rather than
 // silently dropping proxy or custom-CA configuration when TLS is enabled.
-func newContextHTTPClient(cfg *rpcclient.ConnConfig) (*http.Client, error) {
+//
+// maxConns bounds the keep-alive connection pool to the backend. The parallel
+// block ingestor issues many concurrent requests, so the pool must be at least
+// as large as the ingest worker count or the workers serialize on connection
+// setup.
+func newContextHTTPClient(cfg *rpcclient.ConnConfig, maxConns int) (*http.Client, error) {
 	var proxyFunc func(*http.Request) (*url.URL, error)
 	if cfg.Proxy != "" {
 		proxyURL, err := url.Parse(cfg.Proxy)
@@ -60,11 +65,19 @@ func newContextHTTPClient(cfg *rpcclient.ConnConfig) (*http.Client, error) {
 		tlsConfig = &tls.Config{RootCAs: pool}
 	}
 
+	if maxConns < 1 {
+		maxConns = 1
+	}
+
 	return &http.Client{
 		Timeout: defaultHTTPTimeout,
 		Transport: &http.Transport{
-			Proxy:           proxyFunc,
-			TLSClientConfig: tlsConfig,
+			Proxy:               proxyFunc,
+			TLSClientConfig:     tlsConfig,
+			MaxIdleConns:        maxConns,
+			MaxIdleConnsPerHost: maxConns,
+			MaxConnsPerHost:     maxConns,
+			IdleConnTimeout:     90 * time.Second,
 		},
 	}, nil
 }
@@ -79,8 +92,10 @@ func newContextHTTPClient(cfg *rpcclient.ConnConfig) (*http.Client, error) {
 // context-aware request method. Once btcsuite/btcd#2506 (RawRequestWithContext)
 // is merged and released, bump the btcd dependency and replace this with a direct
 // delegation to it: https://github.com/btcsuite/btcd/pull/2506
-func NewContextRawRequest(cfg *rpcclient.ConnConfig) (func(context.Context, string, []json.RawMessage) (json.RawMessage, error), error) {
-	httpClient, err := newContextHTTPClient(cfg)
+//
+// maxConns sizes the keep-alive connection pool; see newContextHTTPClient.
+func NewContextRawRequest(cfg *rpcclient.ConnConfig, maxConns int) (func(context.Context, string, []json.RawMessage) (json.RawMessage, error), error) {
+	httpClient, err := newContextHTTPClient(cfg, maxConns)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +133,9 @@ func NewContextRawRequest(cfg *rpcclient.ConnConfig) (func(context.Context, stri
 			if err != nil {
 				return nil, err
 			}
-			httpReq.Close = true
+			// Deliberately not setting httpReq.Close: btcd's rpcclient closes the
+			// connection after every request, which would force a fresh TCP (and
+			// TLS) handshake per RPC and negate the pool configured above.
 			httpReq.Header.Set("Content-Type", "application/json")
 			for key, value := range cfg.ExtraHeaders {
 				httpReq.Header.Set(key, value)

--- a/frontend/rawrequest_test.go
+++ b/frontend/rawrequest_test.go
@@ -39,7 +39,7 @@ func TestContextRawRequestSuccess(t *testing.T) {
 		HTTPPostMode: true,
 		DisableTLS:   true,
 	}
-	rawRequest, err := NewContextRawRequest(cfg)
+	rawRequest, err := NewContextRawRequest(cfg, 4)
 	if err != nil {
 		t.Fatalf("NewContextRawRequest failed: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestContextRawRequestCancel(t *testing.T) {
 		HTTPPostMode: true,
 		DisableTLS:   true,
 	}
-	rawRequest, err := NewContextRawRequest(cfg)
+	rawRequest, err := NewContextRawRequest(cfg, 4)
 	if err != nil {
 		t.Fatalf("NewContextRawRequest failed: %v", err)
 	}


### PR DESCRIPTION
Speeds up initial sync by fetching blocks concurrently instead of one at a time.

This fix allowed us to scale out lightwalletd quickly to new nodes during the 5.0.0 upgrade last week to meet unprecedented demand without slow initial sync times, it is running in production now.