### PR TITLE
fix(ci): use crane copy with explicit creds for zodlinc Docker Hub push

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -61,18 +61,23 @@ jobs:
             electriccoinco/lightwalletd:${{ github.event.release.tag_name }}
             electriccoinco/lightwalletd:latest
 
-      - name: Log in to Docker Hub (zodlinc)
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.ZODLINC_DOCKERHUB_USERNAME }}
-          password: ${{ secrets.ZODLINC_DOCKERHUB_PASSWORD }}
-
       - name: Push to zodlinc
+        # crane copy with explicit --src-creds and --dst-creds avoids the
+        # docker login session conflict (both registries are docker.io but
+        # different org credentials).
+        env:
+          SRC_USER: ${{ secrets.DOCKERHUB_USERNAME }}
+          SRC_PASS: ${{ secrets.DOCKERHUB_PASSWORD }}
+          DST_USER: ${{ secrets.ZODLINC_DOCKERHUB_USERNAME }}
+          DST_PASS: ${{ secrets.ZODLINC_DOCKERHUB_PASSWORD }}
         run: |
           TAG="${{ github.event.release.tag_name }}"
-          docker buildx imagetools create \
-            --tag zodlinc/lightwalletd:${TAG} \
-            electriccoinco/lightwalletd:${TAG}
-          docker buildx imagetools create \
-            --tag zodlinc/lightwalletd:latest \
-            electriccoinco/lightwalletd:latest
+          go install github.com/google/go-containerregistry/cmd/crane@latest
+          crane copy \
+            --src-creds "${SRC_USER}:${SRC_PASS}" \
+            --dst-creds "${DST_USER}:${DST_PASS}" \
+            electriccoinco/lightwalletd:${TAG} zodlinc/lightwalletd:${TAG}
+          crane copy \
+            --src-creds "${SRC_USER}:${SRC_PASS}" \
+            --dst-creds "${DST_USER}:${DST_PASS}" \
+            electriccoinco/lightwalletd:latest zodlinc/lightwalletd:latest


### PR DESCRIPTION
## Problem

The `docker_push` job for `zodlinc/lightwalletd` fails with `401 Unauthorized` when copying from `electriccoinco/lightwalletd`.

Root cause: `docker login` for zodlinc overwrites the electriccoinco session in `~/.docker/config.json` (both are `registry-1.docker.io`). When `docker buildx imagetools create` then tries to pull the source manifest from electriccoinco, it uses the zodlinc token and gets rejected.

## Fix

Replace `docker login` + `imagetools create` with `crane copy --src-creds --dst-creds`. crane passes credentials inline per-operation without touching `~/.docker/config.json`, so both registries authenticate independently.

## Test plan

- [ ] Merge and re-trigger `docker_push` for v0.5.0 to confirm zodlinc gets the image
- [ ] Verify `zodlinc/lightwalletd:v0.5.0` and `zodlinc/lightwalletd:latest` are published