### PR TITLE
Release v0.5.1: bound oversized client input (GHSA-q2c2, GHSA-6ppp, GHSA-4hp3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,17 @@ The most recent changes are listed first.
 
 ### Fixed
 
+- Validate the size of client-supplied blobs before expanding them.
+  `GetTreeState` now rejects a block hash that isn't 32 bytes
+  (GHSA-q2c2-hpp9-58hm), and `SendTransaction` rejects a raw transaction
+  larger than the 2,000,000-byte Zcash block size limit
+  (GHSA-6ppp-r2gc-9q6v). Both previously hex-encoded the bytes (doubling
+  them) and JSON-marshalled the result before forwarding to zcashd, so an
+  unauthenticated client could force large allocations in lightwalletd, and
+  parsing work in the backend, using input that could only ever be rejected —
+  enough in concurrent requests to drive the process into an out-of-memory
+  kill.
+
 - Bound the transparent-address gRPC methods against unbounded per-request
   work (GHSA-x4m7-3gpp-xc36). `GetTaddressBalanceStream` now caps the number of
   streamed addresses and validates each one as it arrives, instead of buffering

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The most recent changes are listed first.
 
-## [Unreleased]
+## [0.5.1] - 2026-07-27
 
 ### Added
 
@@ -14,6 +14,26 @@ The most recent changes are listed first.
 
 - Add the `--no-backend-check` option, which skips backend detection entirely
   so that lightwalletd can connect to any node that speaks the expected RPCs.
+
+### Fixed
+
+- Validate the size of client-supplied blobs before expanding them.
+  `GetTreeState` now rejects a block hash that isn't 32 bytes
+  (GHSA-q2c2-hpp9-58hm), and `SendTransaction` rejects a raw transaction
+  larger than the 2,000,000-byte Zcash block size limit
+  (GHSA-6ppp-r2gc-9q6v). Both previously hex-encoded the bytes (doubling
+  them) and JSON-marshalled the result before forwarding to zcashd, so an
+  unauthenticated client could force large allocations in lightwalletd, and
+  parsing work in the backend, using input that could only ever be rejected —
+  enough in concurrent requests to drive the process into an out-of-memory
+  kill.
+
+- Cap the `GetMempoolTx` exclude list, and build it before taking the method
+  mutex (GHSA-4hp3-3494-3f2m). Each excluded txid suffix was length-checked,
+  but the number of them was not, so a client could send a very large list and
+  make the server allocate, hex-encode and sort all of it — while holding the
+  mutex, so other `GetMempoolTx` callers stalled behind it, and even when the
+  mempool was empty and the response would be empty too.
 
 ## [0.5.0] - 2026-07-26
 
@@ -37,17 +57,6 @@ The most recent changes are listed first.
   reserved.
 
 ### Fixed
-
-- Validate the size of client-supplied blobs before expanding them.
-  `GetTreeState` now rejects a block hash that isn't 32 bytes
-  (GHSA-q2c2-hpp9-58hm), and `SendTransaction` rejects a raw transaction
-  larger than the 2,000,000-byte Zcash block size limit
-  (GHSA-6ppp-r2gc-9q6v). Both previously hex-encoded the bytes (doubling
-  them) and JSON-marshalled the result before forwarding to zcashd, so an
-  unauthenticated client could force large allocations in lightwalletd, and
-  parsing work in the backend, using input that could only ever be rejected —
-  enough in concurrent requests to drive the process into an out-of-memory
-  kill.
 
 - Bound the transparent-address gRPC methods against unbounded per-request
   work (GHSA-x4m7-3gpp-xc36). `GetTaddressBalanceStream` now caps the number of

--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/zcash/lightwalletd/common"
@@ -61,6 +62,11 @@ func testsetup() (walletrpc.CompactTxStreamerServer, *common.BlockCache) {
 func resetGlobals() {
 	common.RawRequest = nil
 	step = 0
+	// The GetMempoolTx cache is package state too; a test that refreshes it
+	// would otherwise leave the next test looking at a stale mempool.
+	mempoolMap = nil
+	mempoolList = nil
+	lastMempool = time.Time{}
 }
 
 func TestMain(m *testing.M) {
@@ -954,5 +960,64 @@ func TestSendTransactionOversized(t *testing.T) {
 	}
 	if !forwarded {
 		t.Fatal("a transaction at the size limit should have been forwarded")
+	}
+}
+
+type testmempooltx struct {
+	walletrpc.CompactTxStreamer_GetMempoolTxServer
+	sent int
+}
+
+func (t *testmempooltx) Context() context.Context { return context.Background() }
+
+func (t *testmempooltx) Send(tx *walletrpc.CompactTx) error {
+	t.sent++
+	return nil
+}
+
+// An oversized exclude list must be rejected before the server allocates,
+// hex-encodes and sorts it -- work that used to happen while holding the
+// method mutex, stalling other callers (GHSA-4hp3-3494-3f2m). A list at the
+// cap is still accepted, so the bound is not off by one.
+func TestGetMempoolTxExcludeListCap(t *testing.T) {
+	testT = t
+	defer resetGlobals()
+	lwd, _ := testsetup()
+
+	suffixes := make([][]byte, maxExcludeTxidSuffixes+1)
+	for i := range suffixes {
+		suffixes[i] = []byte{1, 2, 3, 4}
+	}
+
+	// Over the cap: rejected locally, zcashd never contacted.
+	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
+		testT.Fatal("zcashd must not be called for an oversized exclude list")
+		return nil, nil
+	}
+	err := lwd.GetMempoolTx(
+		&walletrpc.GetMempoolTxRequest{ExcludeTxidSuffixes: suffixes}, &testmempooltx{})
+	if err == nil {
+		t.Fatal("GetMempoolTx should have failed on an oversized exclude list")
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatal("expected InvalidArgument on oversized exclude list, got:", err)
+	}
+
+	// Exactly at the cap: accepted, and the mempool refresh happens.
+	refreshed := false
+	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
+		if method != "getrawmempool" {
+			testT.Fatal("unexpected method", method)
+		}
+		refreshed = true
+		return []byte("[]"), nil
+	}
+	if err := lwd.GetMempoolTx(
+		&walletrpc.GetMempoolTxRequest{ExcludeTxidSuffixes: suffixes[:maxExcludeTxidSuffixes]},
+		&testmempooltx{}); err != nil {
+		t.Fatal("GetMempoolTx at the exclude-list cap failed:", err)
+	}
+	if !refreshed {
+		t.Fatal("a request at the cap should have reached the backend")
 	}
 }

--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -876,3 +876,83 @@ func TestGetTaddressTransactionsZeroEndIsBounded(t *testing.T) {
 		t.Fatal("GetTaddressTransactions failed:", err)
 	}
 }
+
+// An invalid-length block hash must be rejected before it is hex-expanded and
+// forwarded, so a client can't force large allocations here or parsing work in
+// zcashd with input that can only ever be rejected (GHSA-q2c2-hpp9-58hm).
+func TestGetTreeStateInvalidHashLength(t *testing.T) {
+	testT = t
+	defer resetGlobals()
+	lwd, _ := testsetup()
+
+	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
+		testT.Fatal("zcashd must not be called for an invalid-length block hash")
+		return nil, nil
+	}
+	for _, n := range []int{1, 31, 33, 64, 4 << 20} {
+		_, err := lwd.GetTreeState(context.Background(),
+			&walletrpc.BlockID{Hash: make([]byte, n)})
+		if err == nil {
+			t.Fatal("GetTreeState should have failed on hash length", n)
+		}
+		if status.Code(err) != codes.InvalidArgument {
+			t.Fatal("expected InvalidArgument for hash length", n, "got:", err)
+		}
+	}
+
+	// A correctly-sized hash must still reach zcashd -- the guard must not
+	// reject valid input.
+	forwarded := false
+	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
+		forwarded = true
+		if method != "z_gettreestate" {
+			testT.Fatal("unexpected method", method)
+		}
+		return nil, errors.New("-8: block not found")
+	}
+	_, err := lwd.GetTreeState(context.Background(),
+		&walletrpc.BlockID{Hash: make([]byte, blockHashLen)})
+	if err == nil {
+		t.Fatal("expected the stubbed backend error")
+	}
+	if !forwarded {
+		t.Fatal("a 32-byte hash should have been forwarded to zcashd")
+	}
+}
+
+// An oversized raw transaction must be rejected before it is hex-expanded and
+// forwarded (GHSA-6ppp-r2gc-9q6v). A transaction at exactly the limit is still
+// accepted, so the bound is not off by one.
+func TestSendTransactionOversized(t *testing.T) {
+	testT = t
+	defer resetGlobals()
+	lwd, _ := testsetup()
+
+	// Over the limit: rejected locally, zcashd never contacted.
+	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
+		testT.Fatal("zcashd must not be called for an oversized transaction")
+		return nil, nil
+	}
+	_, err := lwd.SendTransaction(context.Background(),
+		&walletrpc.RawTransaction{Data: make([]byte, maxRawTxSize+1)})
+	if err == nil {
+		t.Fatal("SendTransaction should have failed on an oversized transaction")
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatal("expected InvalidArgument on oversized transaction, got:", err)
+	}
+
+	// Exactly at the limit: forwarded to zcashd.
+	forwarded := false
+	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
+		forwarded = true
+		return json.Marshal("sometxid")
+	}
+	if _, err := lwd.SendTransaction(context.Background(),
+		&walletrpc.RawTransaction{Data: make([]byte, maxRawTxSize)}); err != nil {
+		t.Fatal("SendTransaction at the size limit failed:", err)
+	}
+	if !forwarded {
+		t.Fatal("a transaction at the size limit should have been forwarded")
+	}
+}

--- a/frontend/service.go
+++ b/frontend/service.go
@@ -350,6 +350,9 @@ func (s *lwdStreamer) GetBlockRangeNullifiers(span *walletrpc.BlockRange, resp w
 // GetTreeState returns the note commitment tree state corresponding to the given block.
 // See section 3.7 of the Zcash protocol specification. It returns several other useful
 // values also (even though they can be obtained using GetBlock).
+// blockHashLen is the length in bytes of a Zcash block hash.
+const blockHashLen = len(hash32.T{})
+
 // The block can be specified by either height or hash.
 func (s *lwdStreamer) GetTreeState(ctx context.Context, id *walletrpc.BlockID) (*walletrpc.TreeState, error) {
 	if id.Height == 0 && id.Hash == nil {
@@ -368,6 +371,15 @@ func (s *lwdStreamer) GetTreeState(ctx context.Context, id *walletrpc.BlockID) (
 		common.Log.Debugf("gRPC GetTreeState(height=%+v)\n", id.Height)
 		params[0] = heightJSON
 	} else {
+		// Reject a wrong-length hash before expanding it: the bytes below are
+		// hex-encoded (doubling them) and JSON-marshalled before zcashd ever
+		// sees them, so without this an unauthenticated client can force large
+		// allocations here and parsing work in the backend with input that can
+		// only ever be rejected (GHSA-q2c2-hpp9-58hm).
+		if len(id.Hash) != blockHashLen {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"GetTreeState: block hash has invalid length: %d", len(id.Hash))
+		}
 		// id.Hash is big-endian, keep in big-endian for the rpc
 		hash := hex.EncodeToString(id.Hash)
 		common.Log.Debugf("gRPC GetTreeState(hash=%+v)\n", hash)
@@ -495,6 +507,12 @@ func (s *lwdStreamer) GetLightdInfo(ctx context.Context, in *walletrpc.Empty) (*
 	return lightdinfo, err
 }
 
+// maxRawTxSize bounds the raw transaction bytes lightwalletd will forward to
+// zcashd. A Zcash transaction cannot exceed the 2,000,000-byte block size
+// limit, so anything larger is unminable by definition and there is no reason
+// to spend memory expanding it or to make the backend parse it.
+const maxRawTxSize = 2000000
+
 // SendTransaction forwards raw transaction bytes to a zcashd instance over JSON-RPC
 func (s *lwdStreamer) SendTransaction(ctx context.Context, rawtx *walletrpc.RawTransaction) (*walletrpc.SendResponse, error) {
 	common.Log.Debugf("gRPC SendTransaction(%+v)\n", rawtx)
@@ -508,6 +526,16 @@ func (s *lwdStreamer) SendTransaction(ctx context.Context, rawtx *walletrpc.RawT
 	// Verify rawtx
 	if rawtx == nil || rawtx.Data == nil {
 		return nil, status.Error(codes.InvalidArgument, "bad transaction data")
+	}
+	// Reject an oversized transaction before expanding it: the bytes below are
+	// hex-encoded (doubling them) and JSON-marshalled before zcashd ever sees
+	// them, so without this an unauthenticated client can force large
+	// allocations here and parsing work in the backend with a transaction that
+	// can never be mined (GHSA-6ppp-r2gc-9q6v).
+	if len(rawtx.Data) > maxRawTxSize {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"SendTransaction: transaction is too large: %d bytes (limit %d)",
+			len(rawtx.Data), maxRawTxSize)
 	}
 
 	// Construct raw JSON-RPC params

--- a/frontend/service.go
+++ b/frontend/service.go
@@ -689,8 +689,26 @@ var mempoolList []string
 // Last time we pulled a copy of the mempool from zcashd.
 var lastMempool time.Time
 
+// maxExcludeTxidSuffixes bounds the exclude list a client may send to
+// GetMempoolTx. The list names transactions the caller already has, so it is
+// only ever useful up to the size of the mempool itself; this cap sits well
+// above the number of transactions zcashd's default mempool can hold.
+const maxExcludeTxidSuffixes = 20000
+
 func (s *lwdStreamer) GetMempoolTx(exclude *walletrpc.GetMempoolTxRequest, resp walletrpc.CompactTxStreamer_GetMempoolTxServer) error {
 	common.Log.Debugf("gRPC GetMempoolTx(%+v)\n", exclude)
+	// Each suffix is length-checked below, but the number of them was not
+	// bounded, so a client could submit a huge list and make the server
+	// allocate, hex-encode and sort all of it -- historically while holding
+	// s.mutex, and even when the mempool was empty and the response would be
+	// empty too (GHSA-4hp3-3494-3f2m). The cap is comfortably larger than the
+	// number of transactions zcashd's default mempool can hold, so an exclude
+	// list beyond it cannot describe a useful set in any case.
+	if len(exclude.ExcludeTxidSuffixes) > maxExcludeTxidSuffixes {
+		return status.Errorf(codes.InvalidArgument,
+			"GetMempoolTx: too many exclude txid suffixes: %d (limit %d)",
+			len(exclude.ExcludeTxidSuffixes), maxExcludeTxidSuffixes)
+	}
 	for i := 0; i < len(exclude.ExcludeTxidSuffixes); i++ {
 		if len(exclude.ExcludeTxidSuffixes[i]) > 32 {
 			return status.Errorf(codes.InvalidArgument, "exclude txid %d is larger than 32 bytes", i)
@@ -707,6 +725,18 @@ func (s *lwdStreamer) GetMempoolTx(exclude *walletrpc.GetMempoolTxRequest, resp 
 			walletrpc.PoolType_IRONWOOD,
 		}
 	}
+	// Transform the exclude list before taking the mutex: it depends only on
+	// the request, so doing it in the critical section would let one caller's
+	// large list stall every other GetMempoolTx caller (GHSA-4hp3-3494-3f2m).
+	excludeHex := make([]string, len(exclude.ExcludeTxidSuffixes))
+	for i := range exclude.ExcludeTxidSuffixes {
+		rev := make([]byte, len(exclude.ExcludeTxidSuffixes[i]))
+		for j := range rev {
+			rev[j] = exclude.ExcludeTxidSuffixes[i][len(exclude.ExcludeTxidSuffixes[i])-j-1]
+		}
+		excludeHex[i] = hex.EncodeToString(rev)
+	}
+
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
@@ -781,14 +811,6 @@ func (s *lwdStreamer) GetMempoolTx(exclude *walletrpc.GetMempoolTxRequest, resp 
 			newmempoolMap[txidstr] = tx.ToCompact( /* height */ 0)
 		}
 		mempoolMap = &newmempoolMap
-	}
-	excludeHex := make([]string, len(exclude.ExcludeTxidSuffixes))
-	for i := range exclude.ExcludeTxidSuffixes {
-		rev := make([]byte, len(exclude.ExcludeTxidSuffixes[i]))
-		for j := range rev {
-			rev[j] = exclude.ExcludeTxidSuffixes[i][len(exclude.ExcludeTxidSuffixes[i])-j-1]
-		}
-		excludeHex[i] = hex.EncodeToString(rev)
 	}
 	for _, txid := range MempoolFilter(mempoolList, excludeHex) {
 		ctx, ok := (*mempoolMap)[txid]


### PR DESCRIPTION
Ports the v0.5.1 security fixes to master. Reviewed privately in `lightwalletd-security-fixes` (PRs #4, #5, and release PR #6); this is the public landing.

Fixes three advisories, all reported by **@ipwning**, all with the same shape — a client-supplied blob was expanded (hex-encoded, doubling it, then JSON-marshalled) and forwarded to the backend *before* any size check, so an unauthenticated client could force large allocations in lightwalletd and parsing work in the backend using input that could only ever be rejected:

| Advisory | Handler | Fix |
|---|---|---|
| **GHSA-q2c2-hpp9-58hm** | `GetTreeState` | reject a block hash that isn't 32 bytes |
| **GHSA-6ppp-r2gc-9q6v** | `SendTransaction` | reject a raw transaction over 2,000,000 bytes (the Zcash block size limit, above which a transaction is unminable by definition) |
| **GHSA-4hp3-3494-3f2m** | `GetMempoolTx` | cap the exclude list at 20,000 suffixes, and build it *before* taking the method mutex |

The reporter measured single 3.9 MB requests taking ~11.5 s instead of ~15 ms and adding ~30 MB of heap, with 12–16 concurrent requests OOM-killing a 256 MiB container; and a 120,000-suffix exclude list taking 1209 ms instead of 2 ms while returning zero transactions.

The `GetMempoolTx` change also moves the per-suffix work out of the critical section — it depends only on request data, so holding `s.mutex` across it let one caller's list stall every other `GetMempoolTx` caller.

Each guard rejects with `InvalidArgument`, matching the length check already present in `GetTransaction`.

## Tests

Every new test asserts both halves: that oversized input is rejected **and that zcashd is never contacted**, plus that the bound is not off by one —

- `TestGetTreeStateInvalidHashLength` — lengths 1/31/33/64/4 MiB rejected; a valid 32-byte hash still reaches the backend.
- `TestSendTransactionOversized` — `maxRawTxSize + 1` rejected; exactly `maxRawTxSize` still forwarded.
- `TestGetMempoolTxExcludeListCap` — over the cap rejected; exactly at the cap accepted.

Also extends the `resetGlobals` test helper to clear the mempool cache globals (`mempoolMap`, `mempoolList`, `lastMempool`), which otherwise leak between tests now that one refreshes the cache.

Full suite green under `-race -shuffle=on`; `gofmt` and `go vet` clean.

## CHANGELOG

Adds `## [0.5.1] - 2026-07-27`, covering these fixes plus the zakura backend support from #573. Everything from `[0.5.0]` down is unchanged.
