### PR TITLE
Wait for the backend instead of exiting on RPC failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The most recent changes are listed first.
 
+## [Unreleased]
+
+### Changed
+
+- Wait for the backend node instead of exiting when it is unreachable.
+  `FirstRPC` now retries indefinitely with a capped backoff rather than
+  giving up after ten attempts, and the block ingestor warns and retries on
+  a failed `getbestblockhash` instead of treating it as fatal. This avoids a
+  crash loop when the node is temporarily unavailable, and keeps cached
+  blocks being served while it is away.
+
+  Waiting applies only when the backend cannot be reached. If it answers and
+  rejects our credentials (HTTP 401 or 403), lightwalletd still exits
+  immediately with a message naming the setting to check, since no amount of
+  waiting will fix a bad `rpcuser`/`rpcpassword`. A node that is merely still
+  starting up — zcashd replies to RPCs with error `-28` while it loads the
+  block index — is treated as unreachable, and waited for.
+
 ## [0.5.1] - 2026-07-27
 
 ### Added

--- a/common/backend_error_test.go
+++ b/common/backend_error_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2019-present The Zcash developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php .
+package common
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcjson"
+)
+
+// FirstRPC waits indefinitely for the backend, so it must be able to tell a
+// backend that is merely not up yet from one that is up and refusing our
+// credentials -- the latter never resolves on its own.
+func TestBackendRejectedCredentials(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "http 401 unauthorized",
+			err:  &BackendResponseError{StatusCode: 401, Body: "Unauthorized"},
+			want: true,
+		},
+		{
+			name: "http 403 forbidden",
+			err:  &BackendResponseError{StatusCode: 403, Body: "Forbidden"},
+			want: true,
+		},
+		{
+			// A proxy in front of a restarting node; transient.
+			name: "http 502 bad gateway",
+			err:  &BackendResponseError{StatusCode: 502, Body: "Bad Gateway"},
+			want: false,
+		},
+		{
+			name: "http 503 unavailable",
+			err:  &BackendResponseError{StatusCode: 503, Body: "Service Unavailable"},
+			want: false,
+		},
+		{
+			// zcashd answers with this while starting up. Treating it as fatal
+			// would defeat the point of waiting for the backend at all.
+			name: "jsonrpc -28 still warming up",
+			err:  &btcjson.RPCError{Code: -28, Message: "Loading block index..."},
+			want: false,
+		},
+		{
+			name: "transport error, node not listening",
+			err:  &net.OpError{Op: "dial", Err: errors.New("connection refused")},
+			want: false,
+		},
+		{
+			name: "plain error",
+			err:  errors.New("something else"),
+			want: false,
+		},
+		{
+			// The predicate must see through wrapping, since errors pass through
+			// several layers before reaching FirstRPC.
+			name: "wrapped 401",
+			err:  fmt.Errorf("getblockchaininfo: %w", &BackendResponseError{StatusCode: 401}),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := backendRejectedCredentials(tt.err); got != tt.want {
+				t.Errorf("backendRejectedCredentials(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// The message is user-facing in a Fatal log line, and matches the format the
+// untyped error used before, so operators searching logs still find it.
+func TestBackendResponseErrorMessage(t *testing.T) {
+	err := &BackendResponseError{StatusCode: 401, Body: "Unauthorized"}
+	want := `status code: 401, response: "Unauthorized"`
+	if err.Error() != want {
+		t.Errorf("got %q, want %q", err.Error(), want)
+	}
+}

--- a/common/common.go
+++ b/common/common.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"slices"
 	"strconv"
 	"strings"
@@ -229,6 +230,36 @@ type (
 	}
 )
 
+// BackendResponseError reports that the backend replied with something that
+// isn't a JSON-RPC response, such as an HTTP authentication failure. Unlike a
+// transport error, it means the backend was reachable and rejected the
+// request, so the two cases can be told apart by callers that retry.
+type BackendResponseError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *BackendResponseError) Error() string {
+	return fmt.Sprintf("status code: %d, response: %q", e.StatusCode, e.Body)
+}
+
+// backendRejectedCredentials reports whether err means the backend refused our
+// credentials. That is a configuration error rather than an outage, so waiting
+// for it to clear is pointless.
+//
+// Only authentication statuses count. Other HTTP failures (a 502 from a proxy
+// while the node restarts, say) are transient, and a JSON-RPC error is not
+// treated as fatal either, because zcashd answers with one (code -28) while
+// it is still warming up -- precisely the case we want to keep waiting for.
+func backendRejectedCredentials(err error) bool {
+	var respErr *BackendResponseError
+	if !errors.As(err, &respErr) {
+		return false
+	}
+	return respErr.StatusCode == http.StatusUnauthorized ||
+		respErr.StatusCode == http.StatusForbidden
+}
+
 // FirstRPC tests that we can successfully reach zcashd through the RPC
 // interface. The specific RPC used here is not important.
 func FirstRPC() {
@@ -241,17 +272,32 @@ func FirstRPC() {
 			}
 			break
 		}
-		retryCount++
-		if retryCount > 10 {
+		// Distinguish "the backend isn't up yet" from "the backend is up and
+		// refusing us". Only the former is worth waiting on; bad credentials
+		// will never start working, and retrying forever would turn a typo in
+		// the config into a server that looks merely slow to start.
+		if backendRejectedCredentials(err) {
 			Log.WithFields(logrus.Fields{
-				"timeouts": retryCount,
-			}).Fatal("unable to issue getblockchaininfo RPC call to zebrad or zcashd node")
+				"error": err.Error(),
+			}).Fatal("the " + NodeName + " node rejected our RPC credentials; " +
+				"check rpcuser/rpcpassword (or the cookie file) in the zcash conf")
+		}
+		retryCount++
+		// Otherwise retry indefinitely instead of exiting, so lightwalletd waits for
+		// the backend (zebrad/zcashd) to become reachable rather than crash-looping
+		// when the node is temporarily unavailable — e.g. catching up, or behind a
+		// readiness gate that has emptied its Service. The gRPC server only starts
+		// after FirstRPC returns, so the pod stays not-ready (out of rotation) until
+		// the backend is serving, then comes up cleanly — no CrashLoopBackOff.
+		backoff := 10 + retryCount*5
+		if backoff > 60 {
+			backoff = 60 // cap backoff at 60s
 		}
 		Log.WithFields(logrus.Fields{
 			"error": err.Error(),
 			"retry": retryCount,
 		}).Warn("error with getblockchaininfo rpc, retrying...")
-		Time.Sleep(time.Duration(10+retryCount*5) * time.Second) // backoff
+		Time.Sleep(time.Duration(backoff) * time.Second)
 	}
 }
 
@@ -450,9 +496,14 @@ func BlockIngestor(c *BlockCache, rep int) {
 
 		result, err := RawRequest(context.Background(), "getbestblockhash", []json.RawMessage{})
 		if err != nil {
+			// Retry instead of exiting, so the ingestor tolerates the backend
+			// being temporarily unreachable — it keeps serving cached blocks and
+			// resumes when the backend is back, instead of crash-looping.
 			Log.WithFields(logrus.Fields{
 				"error": err,
-			}).Fatal("error " + NodeName + " getbestblockhash rpc")
+			}).Warn("error " + NodeName + " getbestblockhash rpc, will retry")
+			Time.Sleep(8 * time.Second)
+			continue
 		}
 		var hashHex string
 		err = json.Unmarshal(result, &hashHex)

--- a/frontend/rawrequest.go
+++ b/frontend/rawrequest.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/rpcclient"
+	"github.com/zcash/lightwalletd/common"
 )
 
 const (
@@ -152,8 +153,12 @@ func NewContextRawRequest(cfg *rpcclient.ConnConfig) (func(context.Context, stri
 			}
 			var resp jsonRPCResponse
 			if err := json.Unmarshal(respBytes, &resp); err != nil {
-				return nil, fmt.Errorf("status code: %d, response: %q",
-					httpResp.StatusCode, string(respBytes))
+				// Typed, so callers can tell a reachable-but-rejecting backend
+				// (e.g. an HTTP 401) from one that isn't listening at all.
+				return nil, &common.BackendResponseError{
+					StatusCode: httpResp.StatusCode,
+					Body:       string(respBytes),
+				}
 			}
 			if resp.Error != nil {
 				return nil, resp.Error

--- a/frontend/rawrequest_test.go
+++ b/frontend/rawrequest_test.go
@@ -12,10 +12,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/rpcclient"
+	"github.com/zcash/lightwalletd/common"
 )
 
 func TestContextRawRequestSuccess(t *testing.T) {
@@ -110,5 +112,47 @@ func TestContextRawRequestCancel(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("rawRequest did not return promptly after cancellation")
+	}
+}
+
+// An HTTP-level rejection must surface as a typed *common.BackendResponseError
+// rather than an opaque error, so that FirstRPC can stop waiting on credentials
+// that will never be accepted. A 401 also must not be retried internally --
+// retrying cannot change the outcome.
+func TestContextRawRequestUnauthorizedIsTyped(t *testing.T) {
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("Unauthorized"))
+	}))
+	defer server.Close()
+
+	cfg := &rpcclient.ConnConfig{
+		Host:         server.Listener.Addr().String(),
+		User:         "user",
+		Pass:         "wrong",
+		HTTPPostMode: true,
+		DisableTLS:   true,
+	}
+	rawRequest, err := NewContextRawRequest(cfg)
+	if err != nil {
+		t.Fatalf("NewContextRawRequest failed: %v", err)
+	}
+
+	_, err = rawRequest(context.Background(), "getblockchaininfo", nil)
+	if err == nil {
+		t.Fatal("expected an error for a 401 response")
+	}
+
+	var respErr *common.BackendResponseError
+	if !errors.As(err, &respErr) {
+		t.Fatalf("error is %T (%v), want *common.BackendResponseError", err, err)
+	}
+	if respErr.StatusCode != http.StatusUnauthorized {
+		t.Errorf("StatusCode = %d, want %d", respErr.StatusCode, http.StatusUnauthorized)
+	}
+	if n := atomic.LoadInt32(&attempts); n != 1 {
+		t.Errorf("server saw %d attempts, want 1 (a 401 must not be retried)", n)
 	}
 }


### PR DESCRIPTION
This PR helps lightwalletd run with less restarts in container orchestrators when the backing Zcash node is offline or flaky.

_(Not an NU6.3 urgency. I am in the process of porting over specific lightwalletd changes from the Zec.rocks fork, used on testnet and mainnet over the past year.)_

Lightwalletd will now wait for the backend node instead of exiting when it is unreachable, and will still fail fast without waiting if RPC credentials are incorrect.

Previously, lightwalletd could enter a crash loop whenever its backend was temporarily unavailable: FirstRPC stopped after 10 attempts, and BlockIngestor treated `getbestblockhash` failures as fatal even though it already retried later `getblock` failures.

Both paths now retry transient failures indefinitely. FirstRPC backs off to 60 seconds and delays opening the gRPC listener until the backend is ready. BlockIngestor retries every 8 seconds while continuing to serve cached blocks.

Authentication failures remain fatal: HTTP 401 and 403 now report which setting to check. JSON-RPC errors, including zcashd’s startup `-28`, and other HTTP failures such as proxy 502s are treated as transient.

The raw-request path now returns a typed `common.BackendResponseError` for non-JSON-RPC responses while preserving the existing error message.