### PR TITLE
Use graceful shutdown for gRPC server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The most recent changes are listed first.
 
+## [Unreleased]
+
+### Changed
+
+- On `SIGINT`/`SIGTERM`, stop the gRPC server gracefully so in-flight RPCs can
+  complete, falling back to a forced stop after 30 seconds, instead of exiting
+  immediately. The block cache is now flushed after the server has stopped, so
+  blocks ingested by in-flight requests are included.
+
 ## [0.5.1] - 2026-07-27
 
 ### Added

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -374,13 +374,31 @@ func startServer(opts *common.Options) error {
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		s := <-signals
+		common.Log.WithFields(logrus.Fields{
+			"signal": s.String(),
+		}).Info("caught signal, stopping gRPC server gracefully")
+
+		// Give in-flight RPCs 30 seconds to complete
+		done := make(chan struct{})
+		go func() {
+			server.GracefulStop()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			common.Log.Info("gRPC server stopped gracefully")
+		case <-time.After(30 * time.Second):
+			common.Log.Warn("graceful shutdown timed out, forcing stop")
+			server.Stop()
+		}
+
+		// Flush after the server has stopped, so that blocks ingested by
+		// in-flight RPCs are included. Reached on both the graceful and the
+		// forced path. cache is nil when the block cache is disabled.
 		if cache != nil {
 			cache.Sync()
 		}
-		common.Log.WithFields(logrus.Fields{
-			"signal": s.String(),
-		}).Info("caught signal, stopping gRPC server")
-		os.Exit(1)
 	}()
 
 	err = server.Serve(listener)


### PR DESCRIPTION
_(Not an NU6.3 urgency. I am in the process of porting over specific lightwalletd changes from the Zec.rocks fork, used on testnet and mainnet over the past year.)_

This update enables graceful rollouts of new lightwalletd versions without clients experiencing reset connections. (behind a load balancer)

On SIGINT/SIGTERM the signal handler called os.Exit(1) immediately, so any in-flight RPCs were cut off mid-response, and a routine shutdown reported a non-zero exit status that supervisors read as a crash.

Call server.GracefulStop() instead, falling back to server.Stop() if in-flight RPCs have not finished after 30 seconds. Serve then returns normally and the process exits 0.

Flush the block cache after the server has stopped rather than before, so blocks ingested by in-flight requests are included; this is reached on both the graceful and the forced path. The flush stays nil-guarded, since cache is nil when the block cache is disabled with --nocache.