### PR TITLE
Build a minimal Alpine image in two stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The most recent changes are listed first.
 
+## [Unreleased]
+
+### Changed
+
+- Build the Docker image in two stages on Alpine, shipping only the compiled
+  binary and its runtime dependencies instead of the full Go toolchain and
+  source tree. This takes the image from about 1.9 GB to about 50 MB, and
+  dependency downloads are cached in their own layer so they are not repeated
+  on every source change. The container still runs as root and the
+  `lightwalletd` user still has uid/gid 2002, so no migration is required.
+  Note that the image is now Alpine-based and so has no `bash`; use `sh` for
+  interactive shells into the container.
+
 ## [0.5.1] - 2026-07-27
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,31 @@
-FROM golang:1.25 AS lightwalletd_base
+FROM golang:1.25-alpine AS builder
 
-ADD . /go/src/github.com/zcash/lightwalletd
+RUN apk add --no-cache make git
+
 WORKDIR /go/src/github.com/zcash/lightwalletd
 
-RUN make \
-  && /usr/bin/install -c ./lightwalletd /usr/local/bin/ \
-  && mkdir -p /var/lib/lightwalletd/db \
-  && chown 2002:2002 /var/lib/lightwalletd/db
+# Cache dependencies
+COPY go.mod go.sum ./
+RUN go mod download
 
-ARG LWD_USER=lightwalletd
-ARG LWD_UID=2002
+COPY . .
 
-RUN useradd --home-dir "/srv/$LWD_USER" \
-            --shell /bin/bash \
-            --create-home \
-            --uid "$LWD_UID" \
-            "$LWD_USER"
+RUN make build
 
-WORKDIR "/srv/$LWD_USER"
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates \
+    && adduser -D -h /srv/lightwalletd -u 2002 lightwalletd \
+    && mkdir -p /var/lib/lightwalletd/db \
+    && chown lightwalletd:lightwalletd /var/lib/lightwalletd/db
+
+COPY --from=builder /go/src/github.com/zcash/lightwalletd/lightwalletd /usr/local/bin/
+
+# NB: the container still runs as root, matching the previous image. The
+# lightwalletd user exists and owns the db directory, but switching to it
+# would break existing deployments whose data directories were written as
+# root, so that change is deliberately left separate.
+WORKDIR /srv/lightwalletd
 
 ENTRYPOINT ["lightwalletd"]
 CMD ["--help"]


### PR DESCRIPTION
_(Not an NU6.3 urgency. I am in the process of porting over specific lightwalletd changes from the Zec.rocks fork, used on testnet and mainnet over the past year.)_

Build in a golang:1.25-alpine stage and copy only the resulting binary into an alpine:3.21 runtime, which takes the image from 500MB to ~50MB.

Copy go.mod/go.sum ahead of the source so module downloads are cached in their own layer.

Runtime behavior is deliberately unchanged: the container still runs as root, and the lightwalletd user keeps uid/gid 2002 and ownership of /var/lib/lightwalletd/db, exactly as before. Running as that user is a worthwhile hardening but would break existing deployments whose data directories were written as root, so it is left to a separate change.

The build still runs from a full checkout, so the git describe and git rev-parse in the Makefile continue to stamp version metadata into the binary.

One operator-facing difference: an Alpine base has no bash, so shells into the container may need "ash".