### PR TITLE
Add liveness, readiness, and gRPC health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The most recent changes are listed first.
 
+## [Unreleased]
+
+### Added
+
+- Add Kubernetes-style health endpoints on the existing HTTP port
+  (`--http-bind-addr`, localhost by default), alongside `/metrics`:
+
+  - `GET /livez` reports only that the process is running, and never fails
+    because of the backend node. Restarting lightwalletd cannot fix an
+    unreachable node, so a liveness probe that tracked the backend would turn
+    a backend outage into a restart loop.
+  - `GET /readyz` reports whether the backend node is reachable, returning 503
+    when it is not, so that an instance which cannot serve is taken out of
+    rotation rather than restarted.
+
+- Register the standard `grpc.health.v1.Health` service on the gRPC port, so
+  gRPC-aware load balancers can health-check the port that actually serves
+  traffic.
+
+  Both the readiness probe and the gRPC health service are driven by a single
+  background poll of the backend, so they cannot disagree, and neither issues
+  a backend RPC per request.
+
 ## [0.5.1] - 2026-07-27
 
 ### Added

--- a/cmd/health.go
+++ b/cmd/health.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2019-present The Zcash developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php .
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/zcash/lightwalletd/common"
+)
+
+// backendPollInterval is how often the backend node is checked on behalf of the
+// readiness probe and the gRPC health service.
+const backendPollInterval = 5 * time.Second
+
+// backendReady records whether the backend node was reachable as of the last
+// poll. The probes read this rather than querying the backend themselves, so
+// that however often they are called -- including by something that isn't a
+// probe at all -- they never turn into load on the node.
+var backendReady atomic.Bool
+
+// checkBackend reports whether the backend node is answering RPCs.
+// getblockchaininfo is used because it is the cheapest call that proves the
+// node is actually serving, rather than merely accepting connections.
+func checkBackend() error {
+	_, err := common.GetBlockChainInfo()
+	return err
+}
+
+// pollBackendHealth keeps backendReady and the gRPC health service current for
+// the life of the process. Running one poller, rather than checking on each
+// request, also keeps the two probes from ever disagreeing.
+func pollBackendHealth(healthServer *health.Server) {
+	var reported bool
+	first := true
+	for {
+		err := checkBackend()
+		ready := err == nil
+		backendReady.Store(ready)
+
+		status := healthpb.HealthCheckResponse_NOT_SERVING
+		if ready {
+			status = healthpb.HealthCheckResponse_SERVING
+		}
+		healthServer.SetServingStatus("", status)
+
+		// Log transitions only; the backend being down for a while should not
+		// fill the log with one line per poll.
+		if first || ready != reported {
+			if ready {
+				if !first {
+					common.Log.Info("backend is reachable again, reporting ready")
+				}
+			} else {
+				common.Log.WithFields(logrus.Fields{
+					"error": err,
+				}).Warn("backend is unreachable, reporting not ready")
+			}
+			reported = ready
+			first = false
+		}
+		time.Sleep(backendPollInterval)
+	}
+}
+
+// livezHandler answers the liveness probe: is this process running at all?
+//
+// It deliberately ignores the backend. Restarting lightwalletd cannot fix an
+// unreachable node, so a liveness probe that failed on backend outages would
+// turn a backend blip into a restart loop -- exactly the crash looping that
+// waiting for the backend on startup is meant to avoid.
+func livezHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintln(w, "ok")
+}
+
+// readyzHandler answers the readiness probe: can this instance serve wallet
+// requests? That requires the backend node, so a failure here should take the
+// instance out of rotation without restarting it.
+func readyzHandler(w http.ResponseWriter, r *http.Request) {
+	if !backendReady.Load() {
+		http.Error(w, "backend unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintln(w, "ok")
+}

--- a/cmd/health_test.go
+++ b/cmd/health_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2019-present The Zcash developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php .
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Liveness must not depend on the backend. If it did, a backend outage would
+// make Kubernetes restart lightwalletd, which cannot fix an unreachable node
+// and would produce a restart loop.
+func TestLivezIgnoresBackend(t *testing.T) {
+	prev := backendReady.Load()
+	defer backendReady.Store(prev)
+
+	for _, ready := range []bool{true, false} {
+		backendReady.Store(ready)
+		rec := httptest.NewRecorder()
+		livezHandler(rec, httptest.NewRequest(http.MethodGet, "/livez", nil))
+		if rec.Code != http.StatusOK {
+			t.Errorf("backendReady=%v: got status %d, want %d", ready, rec.Code, http.StatusOK)
+		}
+	}
+}
+
+// Readiness must track the backend, so an instance that cannot serve is taken
+// out of rotation rather than restarted.
+func TestReadyzTracksBackend(t *testing.T) {
+	prev := backendReady.Load()
+	defer backendReady.Store(prev)
+
+	tests := []struct {
+		ready bool
+		want  int
+	}{
+		{ready: true, want: http.StatusOK},
+		{ready: false, want: http.StatusServiceUnavailable},
+	}
+	for _, tt := range tests {
+		backendReady.Store(tt.ready)
+		rec := httptest.NewRecorder()
+		readyzHandler(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+		if rec.Code != tt.want {
+			t.Errorf("backendReady=%v: got status %d, want %d", tt.ready, rec.Code, tt.want)
+		}
+	}
+}
+
+// The probes read cached state rather than calling the backend, so that however
+// often they are hit they cannot amplify into load on the node. RawRequest is
+// left nil here: if a handler tried to reach the backend it would panic.
+func TestProbesDoNotCallBackend(t *testing.T) {
+	prev := backendReady.Load()
+	defer backendReady.Store(prev)
+	backendReady.Store(true)
+
+	for i := 0; i < 100; i++ {
+		livezHandler(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/livez", nil))
+		readyzHandler(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,8 @@ import (
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 
 	"github.com/zcash/lightwalletd/common"
@@ -182,6 +184,13 @@ func startServer(opts *common.Options) error {
 	}
 	grpc_prometheus.EnableHandlingTimeHistogram()
 	grpc_prometheus.Register(server)
+
+	// The standard gRPC health service, so that gRPC-aware load balancers can
+	// check the port that actually serves traffic. Its status is driven by the
+	// same poller as the HTTP readiness probe, so the two always agree.
+	healthServer := health.NewServer()
+	healthpb.RegisterHealthServer(server, healthServer)
+
 	go startHTTPServer(opts)
 
 	// Enable reflection for debugging
@@ -358,6 +367,11 @@ func startServer(opts *common.Options) error {
 		walletrpc.RegisterDarksideStreamerServer(server, service)
 	}
 
+	// Started once the RPC client is wired up, so the first poll can reach the
+	// backend. Until it completes, readiness reports not-ready, which is the
+	// safe default for an instance that hasn't yet confirmed it can serve.
+	go pollBackendHealth(healthServer)
+
 	common.Log.Infof("Starting gRPC server on %s", opts.GRPCBindAddr)
 
 	// Start listening
@@ -529,7 +543,13 @@ func initConfig() {
 	}
 }
 
+// startHTTPServer serves the operational endpoints -- Prometheus metrics and
+// the Kubernetes probes -- on HTTPBindAddr, which defaults to localhost. These
+// are deliberately kept off the gRPC port so that none of them is reachable by
+// wallet clients.
 func startHTTPServer(opts *common.Options) {
 	http.Handle("/metrics", promhttp.Handler())
+	http.HandleFunc("/livez", livezHandler)
+	http.HandleFunc("/readyz", readyzHandler)
 	http.ListenAndServe(opts.HTTPBindAddr, nil)
 }


### PR DESCRIPTION
_(Not an NU6.3 urgency. I am in the process of porting over specific lightwalletd changes from the Zec.rocks fork, used on testnet and mainnet over the past year.)_

lightwalletd had no health endpoint, so an orchestrator or load balancer had no way to tell whether an instance could serve, short of making a real gRPC call.

Add the two probes that Kubernetes/Docker/etc expect, on the existing HTTP port (--http-bind-addr, localhost by default) next to /metrics:

GET /livez  - the process is running. Deliberately independent of the backend: restarting lightwalletd cannot fix an unreachable node, so a liveness probe that tracked the backend would turn a backend outage into a restart loop.

GET /readyz - the backend is reachable, 503 when it is not, so an instance that cannot serve leaves the Service endpoints without being restarted.

Keeping these on a dedicated port is standard for orchestrator use, and helpful here because not many orchestrators speak gRPC. Kubernetes only supports gRPC's grpc.health.v1.Health service, which this PR also adds.

Normally exposing health on a potentially client-facing port is a leak concern, but lightwalletd already exposes backend health in GetLightdInfo.

A single background poller drives both the readiness probe and the gRPC health status, so the two can never disagree, and neither issues a backend RPC per request -- however often they are called, the load on the node is one getblockchaininfo per poll interval. The poller logs only on transitions, so a backend that stays down does not fill the log.