### PR TITLE
Remove zcashd support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The most recent changes are listed first.
 
+## [Unreleased]
+
+### Removed
+
+- Remove zcashd-specific backend support, as zcashd is fully deprecated and
+  no longer runs on mainnet or testnet. The zcashd (`MagicBean`) branch of
+  the backend detection and its `getexperimentalfeatures` check are gone;
+  zebrad and zakura remain recognized backends, and `--no-backend-check`
+  still allows connecting to any node that speaks the expected RPCs.
+
+- Remove the stale zcashd-specific Makefile docker targets, and rewrite
+  `utils/pullblocks.sh` to use JSON-RPC directly instead of `zcash-cli`.
+
+### Changed
+
+- Documentation, comments, and internal type names now refer to the backend
+  generically as the "Zcash node" rather than zcashd.
+
+No operator-facing interfaces changed: the `--zcash-conf-path` option, the
+supported config file formats (`zcash.conf`-style INI and TOML),
+environment variables, and the docker-compose files are all unchanged
+(updating the docker-compose stack is planned as a follow-up). The
+`zcashdBuild` and `zcashdSubversion` fields of the `LightdInfo` gRPC message
+keep their names for wire compatibility and report the connected node's build
+and subversion strings.
+
 ## [0.5.1] - 2026-07-27
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -96,26 +96,6 @@ lwd-api.html: walletrpc/compact_formats.proto walletrpc/service.proto
 docker_img:
 	docker build -t zcash_lwd_base .
 
-# Run the above docker image in a container
-docker_img_run:
-	docker run -i --name zcashdlwd zcash_lwd_base
-
-# Execute a bash process on zcashdlwdcontainer
-docker_img_bash:
-	docker exec -it zcashdlwd bash
-
-# Start the zcashd process in the zcashdlwd container
-docker_img_run_zcashd:
-	docker exec -i zcashdlwd zcashd -printtoconsole
-
-# Stop the zcashd process in the zcashdlwd container
-docker_img_stop_zcashd:
-	docker exec -i zcashdlwd zcash-cli stop
-
-# Start the lightwalletd server in the zcashdlwd container
-docker_img_run_lightwalletd_insecure_server:
-	docker exec -i zcashdlwd server --no-tls-very-insecure=true --conf-file /home/zcash/.zcash/zcash.conf --log-file /logs/server.log --bind-addr 127.0.0.1:18232
-
 # Remove and delete ALL images and containers in Docker; assumes containers are stopped
 docker_remove_all:
 	docker system prune -f

--- a/README.md
+++ b/README.md
@@ -33,23 +33,26 @@ Documentation for lightwalletd clients (the gRPC interface) is in `docs/rtd/inde
 
 # Local/Developer Usage
 
-## Zcashd
+## Zcash node
 
-You must start a local instance of `zcashd`, and its `.zcash/zcash.conf` file must include the following entries
-(set the user and password strings accordingly):
-```
-txindex=1
-lightwalletd=1
-experimentalfeatures=1
-rpcuser=xxxxx
-rpcpassword=xxxxx
+You must have access to a Zcash full node (such as [zebrad](https://zebra.zfnd.org/)
+or zakura) with its JSON-RPC interface enabled. For zebrad, the `zebrad.toml` configuration
+file must enable the RPC listener, for example:
+```toml
+[rpc]
+listen_addr = "127.0.0.1:8232"
 ```
 
-The `zcashd` can be configured to run `mainnet` or `testnet` (or `regtest`). If you stop `zcashd` and restart it on a different network (switch from `testnet` to `mainnet`, for example), you must also stop and restart lightwalletd.
+Then point lightwalletd at the node's RPC endpoint using the `--rpchost`,
+`--rpcport`, `--rpcuser`, and `--rpcpassword` options (all four must be given;
+if the node does not check RPC credentials, any values work). Note that the
+node's own configuration file (such as `zebrad.toml`) is not a suitable
+argument for `--zcash-conf-path`: its RPC address is the node's *bind* address,
+which is not necessarily an address that lightwalletd can reach.
 
-It's necessary to run `zcashd --reindex` one time for these options to take effect. This typically takes several hours, and requires more space in the `.zcash` data directory.
+The node can be configured to run on mainnet or testnet. If you stop the node and restart it on a different network, you must also stop and restart lightwalletd.
 
-Lightwalletd uses the following `zcashd` RPCs:
+Lightwalletd uses the following node RPCs:
 - `getinfo`
 - `getblockchaininfo`
 - `getbestblockhash`
@@ -74,13 +77,13 @@ your `$GOPATH` (`$HOME/go` by default), then build the lightwalletd server binar
 Assuming you used `make` to build the server, here's a typical developer invocation:
 
 ```
-./lightwalletd --no-tls-very-insecure --zcash-conf-path ~/.zcash/zcash.conf --data-dir . --log-file /dev/stdout
+./lightwalletd --no-tls-very-insecure --rpchost 127.0.0.1 --rpcport 8232 --rpcuser x --rpcpassword x --data-dir . --log-file /dev/stdout
 ```
 Type `./lightwalletd help` to see the full list of options and arguments.
 
 # Production Usage
 
-Run a local instance of `zcashd` (see above), except do _not_ specify `--no-tls-very-insecure`.
+Run a local Zcash node (see above), except do _not_ specify `--no-tls-very-insecure`.
 Ensure [Go](https://golang.org/dl/#stable) version 1.17 or later is installed.
 
 **x509 Certificates**
@@ -112,7 +115,7 @@ certbot certonly --standalone --preferred-challenges http -d some.forward.dns.co
 Example using server binary built from Makefile:
 
 ```
-./lightwalletd --tls-cert cert.pem --tls-key key.pem --zcash-conf-path /home/zcash/.zcash/zcash.conf --log-file /logs/server.log
+./lightwalletd --tls-cert cert.pem --tls-key key.pem --rpchost 127.0.0.1 --rpcport 8232 --rpcuser x --rpcpassword x --log-file /logs/server.log
 ```
 
 ## Block cache
@@ -129,7 +132,7 @@ the `--data-dir` command-line option).
 lightwalletd checks the consistency of these files at startup and during
 operation as these files may be damaged by, for example, an unclean shutdown.
 If the server detects corruption, it will automatically re-downloading blocks
-from `zcashd` from that height, requiring up to an hour again (no manual
+from the node from that height, requiring up to an hour again (no manual
 intervention is required). But this should occur rarely.
 
 If lightwalletd detects corruption in these cache files, it will log

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,8 +4,6 @@
 package cmd
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -15,8 +13,6 @@ import (
 	"strings"
 	"syscall"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/btcsuite/btcd/rpcclient"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
@@ -189,7 +185,7 @@ func startServer(opts *common.Options) error {
 		reflection.Register(server)
 	}
 
-	// Initialize Zcash RPC client. Right now (Jan 2018) this is only for
+	// Initialize the Zcash node RPC client. Right now (Jan 2018) this is only for
 	// sending transactions, but in the future it could back a different type
 	// of block streamer.
 
@@ -207,30 +203,30 @@ func startServer(opts *common.Options) error {
 		if err != nil {
 			common.Log.WithFields(logrus.Fields{
 				"error": err,
-			}).Fatal("setting up RPC connection to zebrad or zcashd")
+			}).Fatal("setting up RPC connection to the Zcash node")
 		}
 		_, err = rpcclient.New(connCfg, nil)
 		if err != nil {
 			common.Log.WithFields(logrus.Fields{
 				"error": err,
-			}).Fatal("setting up RPC connection to zebrad or zcashd")
+			}).Fatal("setting up RPC connection to the Zcash node")
 		}
 		// Indirect function for test mocking (so unit tests can talk to stub functions).
 		common.RawRequest, err = frontend.NewContextRawRequest(connCfg)
 		if err != nil {
 			common.Log.WithFields(logrus.Fields{
 				"error": err,
-			}).Fatal("setting up RPC connection to zebrad or zcashd")
+			}).Fatal("setting up RPC connection to the Zcash node")
 		}
 
-		// Ensure that we can communicate with zcashd
+		// Ensure that we can communicate with the Zcash node
 		common.FirstRPC()
 
 		getLightdInfo, err := common.GetLightdInfo()
 		if err != nil {
 			common.Log.WithFields(logrus.Fields{
 				"error": err,
-			}).Fatal("getting initial information from zebrad or zcashd")
+			}).Fatal("getting initial information from the Zcash node")
 		}
 		common.Log.Info("Got sapling height ", getLightdInfo.SaplingActivationHeight,
 			" block height ", getLightdInfo.BlockHeight,
@@ -249,48 +245,18 @@ func startServer(opts *common.Options) error {
 			backend = "zakura"
 		case strings.Contains(subver, "/Zebra:"):
 			backend = "zebrad"
-		case strings.Contains(subver, "/MagicBean:"):
-			backend = "zcashd"
-		}
-		if backend != "" {
-			common.NodeName = backend
 		}
 
-		// Verify that the backend is one we know how to talk to and, for
-		// zcashd, that the required experimental features are enabled.
-		// --no-backend-check skips all of this, allowing lightwalletd to
+		// Verify that the backend is one we know how to talk to.
+		// --no-backend-check skips this, allowing lightwalletd to
 		// connect to any node that speaks the expected RPCs.
 		if opts.NoBackendCheck {
 			common.Log.Warn("--no-backend-check given; not verifying the backend, subversion ", subver)
+		} else if backend != "" {
+			common.Log.Info("Detected ", backend, " backend")
 		} else {
-			switch backend {
-			case "zebrad", "zakura":
-				common.Log.Info("Detected ", backend, " backend; skipping experimental feature check")
-
-			case "zcashd":
-				result, rpcErr := common.RawRequest(context.Background(), "getexperimentalfeatures", []json.RawMessage{})
-				if rpcErr != nil {
-					common.Log.Fatalf("zcashd backend detected but getexperimentalfeatures RPC failed: %s", rpcErr.Error())
-				}
-
-				var feats []string
-				if err := json.Unmarshal(result, &feats); err != nil {
-					common.Log.Info("failed to decode getexperimentalfeatures reply: %w", err)
-				}
-
-				switch {
-				case slices.Contains(feats, "lightwalletd"):
-				case slices.Contains(feats, "insightexplorer"):
-				default:
-					common.Log.Fatal(
-						"zcashd is running without the required experimental feature enabled; " +
-							"enable 'lightwalletd' or 'insightexplorer'")
-				}
-
-			default:
-				common.Log.Fatalf("unsupported backend subversion %q (expected zebrad, zakura, or the "+
-					"deprecated zcashd); use --no-backend-check to connect anyway", subver)
-			}
+			common.Log.Fatalf("unsupported backend subversion %q (expected zebrad or zakura); "+
+				"use --no-backend-check to connect anyway", subver)
 		}
 	}
 
@@ -417,15 +383,15 @@ func init() {
 	rootCmd.Flags().String("rpcpassword", "", "RPC password")
 	rootCmd.Flags().String("rpchost", "", "RPC host")
 	rootCmd.Flags().String("rpcport", "", "RPC host port")
-	rootCmd.Flags().Bool("no-backend-check", false, "don't verify that the backend node is zebrad, zakura or zcashd; connect to any node")
+	rootCmd.Flags().Bool("no-backend-check", false, "don't verify that the backend node is zebrad or zakura; connect to any node")
 	rootCmd.Flags().Bool("no-tls-very-insecure", false, "run without the required TLS certificate, only for debugging, DO NOT use in production")
 	rootCmd.Flags().Bool("gen-cert-very-insecure", false, "run with self-signed TLS certificate, only for debugging, DO NOT use in production")
-	rootCmd.Flags().Bool("redownload", false, "re-fetch all blocks from zebrad or zcashd; reinitialize local cache files")
+	rootCmd.Flags().Bool("redownload", false, "re-fetch all blocks from the Zcash node; reinitialize local cache files")
 	rootCmd.Flags().Bool("nocache", false, "don't maintain a compact blocks disk cache (to reduce storage)")
-	rootCmd.Flags().Int("sync-from-height", -1, "re-fetch blocks from zebrad or zcashd, starting at this height")
+	rootCmd.Flags().Int("sync-from-height", -1, "re-fetch blocks from the Zcash node, starting at this height")
 	rootCmd.Flags().String("data-dir", "/var/lib/lightwalletd", "data directory (such as db)")
 	rootCmd.Flags().Bool("ping-very-insecure", false, "allow Ping GRPC for testing")
-	rootCmd.Flags().Bool("darkside-very-insecure", false, "run with GRPC-controllable mock zebrad for integration testing (shuts down after 30 minutes)")
+	rootCmd.Flags().Bool("darkside-very-insecure", false, "run with GRPC-controllable mock Zcash node for integration testing (shuts down after 30 minutes)")
 	rootCmd.Flags().Int("darkside-timeout", 30, "override 30 minute default darkside timeout")
 	rootCmd.Flags().String("donation-address", "", "Zcash UA address to accept donations for operating this server")
 

--- a/common/cache.go
+++ b/common/cache.go
@@ -260,7 +260,7 @@ func (c *BlockCache) Add(height int, block *walletrpc.CompactBlock) error {
 	bheight := int(block.Height)
 
 	if bheight != height {
-		// This could only happen if zcashd returned the wrong
+		// This could only happen if the node returned the wrong
 		// block (not the height we requested).
 		Log.Fatal("cache.Add wrong height: ", bheight, " expecting: ", height)
 		return nil

--- a/common/common.go
+++ b/common/common.go
@@ -30,7 +30,6 @@ var (
 	Branch          = ""
 	BuildDate       = ""
 	BuildUser       = ""
-	NodeName        = "zebrad"
 	DonationAddress = ""
 )
 
@@ -59,9 +58,9 @@ type Options struct {
 	DarksideTimeout     uint64 `json:"darkside_timeout"`
 }
 
-// RawRequest points to the function to send an RPC request to zcashd;
+// RawRequest points to the function to send an RPC request to the Zcash node;
 // in production, it points to frontend.NewContextRawRequest();
-// in unit tests it points to a function to mock RPCs to zcashd.
+// in unit tests it points to a function to mock RPCs to the node.
 var RawRequest func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error)
 
 // Time allows time-related functions to be mocked for testing,
@@ -79,9 +78,10 @@ var Time struct {
 // Log as a global variable simplifies logging
 var Log *logrus.Entry
 
-// The following are JSON zcashd rpc requests and replies.
+// The following are the JSON-RPC requests and replies exchanged
+// with the backend Zcash node.
 type (
-	// zcashd rpc "getblockchaininfo"
+	// rpc "getblockchaininfo"
 	Upgradeinfo struct {
 		// unneeded fields can be omitted
 		Name             string
@@ -92,7 +92,7 @@ type (
 		Nextblock string // example: "e9ff75a6" (canopy)
 		Chaintip  string // example: "e9ff75a6" (canopy)
 	}
-	ZcashdRpcReplyGetblockchaininfo struct {
+	RpcReplyGetblockchaininfo struct {
 		Chain           string
 		Upgrades        map[string]Upgradeinfo
 		Blocks          int
@@ -101,22 +101,22 @@ type (
 		EstimatedHeight int
 	}
 
-	// zcashd rpc "getinfo"
-	// Note, this rpc should not be depended on in the future (being deprecated).
-	ZcashdRpcReplyGetinfo struct {
+	// rpc "getinfo", which supplies the backend build and subversion
+	// strings reported by the LightdInfo gRPC.
+	RpcReplyGetinfo struct {
 		Build      string
 		Subversion string
 	}
 
-	// zcashd rpc "getaddresstxids"
-	ZcashdRpcRequestGetaddresstxids struct {
+	// rpc "getaddresstxids"
+	RpcRequestGetaddresstxids struct {
 		Addresses []string `json:"addresses"`
 		Start     uint64   `json:"start"`
 		End       uint64   `json:"end,omitempty"`
 	}
 
-	// zcashd rpc "z_gettreestate"
-	ZcashdRpcReplyGettreestate struct {
+	// rpc "z_gettreestate"
+	RpcReplyGettreestate struct {
 		Height  int
 		Hash    string
 		Time    uint32
@@ -140,26 +140,26 @@ type (
 		}
 	}
 
-	// zcashd rpc "getrawtransaction txid 1" (1 means verbose), there are
+	// rpc "getrawtransaction txid 1" (1 means verbose), there are
 	// many more fields but these are the only ones we current need.
-	ZcashdRpcReplyGetrawtransaction struct {
+	RpcReplyGetrawtransaction struct {
 		Hex    string
 		Height int64
 	}
 
-	// zcashd rpc "getaddressbalance"
-	ZcashdRpcRequestGetaddressbalance struct {
+	// rpc "getaddressbalance"
+	RpcRequestGetaddressbalance struct {
 		Addresses []string `json:"addresses"`
 	}
-	ZcashdRpcReplyGetaddressbalance struct {
+	RpcReplyGetaddressbalance struct {
 		Balance int64
 	}
 
-	// zcashd rpc "getaddressutxos"
-	ZcashdRpcRequestGetaddressutxos struct {
+	// rpc "getaddressutxos"
+	RpcRequestGetaddressutxos struct {
 		Addresses []string `json:"addresses"`
 	}
-	ZcashdRpcReplyGetaddressutxos struct {
+	RpcReplyGetaddressutxos struct {
 		Address     string
 		Txid        string
 		OutputIndex int64
@@ -169,7 +169,7 @@ type (
 	}
 
 	// reply to getblock verbose=1 (json includes txid list)
-	ZcashRpcReplyGetblock1 struct {
+	RpcReplyGetblock1 struct {
 		Hash  string
 		Tx    []string
 		Trees struct {
@@ -203,7 +203,7 @@ type (
 	//
 	// Here is that example, except return (up to) 2 entries:
 	//
-	// $ zcash-cli z_getsubtreesbyindex sapling 0 2
+	// $ z_getsubtreesbyindex sapling 0 2
 	// {
 	//  "pool": "sapling",
 	//  "start_index": 0,
@@ -224,12 +224,12 @@ type (
 		End_height int
 	}
 
-	ZcashdRpcReplyGetsubtreebyindex struct {
+	RpcReplyGetsubtreebyindex struct {
 		Subtrees []Subtree
 	}
 )
 
-// FirstRPC tests that we can successfully reach zcashd through the RPC
+// FirstRPC tests that we can successfully reach the Zcash node through the RPC
 // interface. The specific RPC used here is not important.
 func FirstRPC() {
 	retryCount := 0
@@ -245,7 +245,7 @@ func FirstRPC() {
 		if retryCount > 10 {
 			Log.WithFields(logrus.Fields{
 				"timeouts": retryCount,
-			}).Fatal("unable to issue getblockchaininfo RPC call to zebrad or zcashd node")
+			}).Fatal("unable to issue getblockchaininfo RPC call to the Zcash node")
 		}
 		Log.WithFields(logrus.Fields{
 			"error": err.Error(),
@@ -255,12 +255,12 @@ func FirstRPC() {
 	}
 }
 
-func GetBlockChainInfo() (*ZcashdRpcReplyGetblockchaininfo, error) {
+func GetBlockChainInfo() (*RpcReplyGetblockchaininfo, error) {
 	result, rpcErr := RawRequest(context.Background(), "getblockchaininfo", []json.RawMessage{})
 	if rpcErr != nil {
 		return nil, rpcErr
 	}
-	var getblockchaininfoReply ZcashdRpcReplyGetblockchaininfo
+	var getblockchaininfoReply RpcReplyGetblockchaininfo
 	err := json.Unmarshal(result, &getblockchaininfoReply)
 	if err != nil {
 		return nil, err
@@ -273,7 +273,7 @@ func GetLightdInfo() (*walletrpc.LightdInfo, error) {
 	if rpcErr != nil {
 		return nil, rpcErr
 	}
-	var getinfoReply ZcashdRpcReplyGetinfo
+	var getinfoReply RpcReplyGetinfo
 	err := json.Unmarshal(result, &getinfoReply)
 	if err != nil {
 		return nil, err
@@ -283,7 +283,7 @@ func GetLightdInfo() (*walletrpc.LightdInfo, error) {
 	if rpcErr != nil {
 		return nil, rpcErr
 	}
-	var getblockchaininfoReply ZcashdRpcReplyGetblockchaininfo
+	var getblockchaininfoReply RpcReplyGetblockchaininfo
 	err = json.Unmarshal(result, &getblockchaininfoReply)
 	if err != nil {
 		return nil, err
@@ -351,13 +351,13 @@ func getBlockFromRPC(ctx context.Context, height int) (*walletrpc.CompactBlock, 
 	params := []json.RawMessage{heightJSON, json.RawMessage("1")}
 	result, rpcErr := RawRequest(ctx, "getblock", params)
 	if rpcErr != nil {
-		// Check to see if we are requesting a height the zcashd doesn't have yet
+		// Check to see if we are requesting a height the node doesn't have yet
 		if (strings.Split(rpcErr.Error(), ":"))[0] == "-8" {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("error requesting verbose block: %w", rpcErr)
 	}
-	var block1 ZcashRpcReplyGetblock1
+	var block1 RpcReplyGetblock1
 	err = json.Unmarshal(result, &block1)
 	if err != nil {
 		Log.Fatal("getBlockFromRPC: Can't unmarshal block:", err)
@@ -433,7 +433,7 @@ func stopIngestor() {
 	}
 }
 
-// BlockIngestor runs as a goroutine and polls zcashd for new blocks, adding them
+// BlockIngestor runs as a goroutine and polls the Zcash node for new blocks, adding them
 // to the cache. The repetition count, rep, is nonzero only for unit-testing.
 func BlockIngestor(c *BlockCache, rep int) {
 	lastLog := Time.Now()
@@ -452,7 +452,7 @@ func BlockIngestor(c *BlockCache, rep int) {
 		if err != nil {
 			Log.WithFields(logrus.Fields{
 				"error": err,
-			}).Fatal("error " + NodeName + " getbestblockhash rpc")
+			}).Fatal("error getbestblockhash rpc")
 		}
 		var hashHex string
 		err = json.Unmarshal(result, &hashHex)
@@ -496,7 +496,7 @@ func BlockIngestor(c *BlockCache, rep int) {
 		}
 		if height == c.GetFirstHeight() {
 			c.Sync()
-			Log.Info("Waiting for "+NodeName+" height to reach Sapling activation height ",
+			Log.Info("Waiting for the node height to reach Sapling activation height ",
 				"(", c.GetFirstHeight(), ")...")
 			Time.Sleep(120 * time.Second)
 			continue
@@ -507,7 +507,7 @@ func BlockIngestor(c *BlockCache, rep int) {
 }
 
 // GetBlock returns the compact block at the requested height, first by querying
-// the cache, then, if not found, will request the block from zcashd. It returns
+// the cache, then, if not found, will request the block from the node. It returns
 // nil if no block exists at this height.
 // This returns gRPC-compatible errors.
 func GetBlock(ctx context.Context, cache *BlockCache, height int) (*walletrpc.CompactBlock, error) {
@@ -642,15 +642,15 @@ func GetBlockRange(ctx context.Context, cache *BlockCache, blockOut chan<- *wall
 	}
 }
 
-// ParseRawTransaction converts between the JSON result of a `zcashd`
+// ParseRawTransaction converts between the JSON result of a
 // `getrawtransaction` call and the `RawTransaction` protobuf type.
 //
 // Due to an error in the original protobuf definition, it is necessary to
-// reinterpret the result of the `getrawtransaction` RPC call. Zcashd will
-// return the int64 value `-1` for the height of transactions that appear in
+// reinterpret the result of the `getrawtransaction` RPC call. The backend
+// returns the int64 value `-1` for the height of transactions that appear in
 // the block index, but which are not mined in the main chain. `service.proto`
 // defines the height field of `RawTransaction` to be a `uint64`, and as such
-// we must map the response from the zcashd RPC API to be representable within
+// we must map the response from the RPC API to be representable within
 // this space. Additionally, the `height` field will be absent for transactions
 // in the mempool, resulting in the default value of `0` being set. Therefore,
 // the meanings of the `Height` field of the `RawTransaction` type are as
@@ -663,7 +663,7 @@ func GetBlockRange(ctx context.Context, cache *BlockCache, blockOut chan<- *wall
 //     given height
 func ParseRawTransaction(message json.RawMessage) (*walletrpc.RawTransaction, error) {
 	// Many other fields are returned, but we need only these two.
-	var txinfo ZcashdRpcReplyGetrawtransaction
+	var txinfo RpcReplyGetrawtransaction
 	err := json.Unmarshal(message, &txinfo)
 	if err != nil {
 		return nil, err

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -116,7 +116,7 @@ func resetGlobals() {
 	sleepCount = 0
 	sleepDuration = 0
 	DonationAddress = ""
-	g_lastBlockChainInfo = &ZcashdRpcReplyGetblockchaininfo{}
+	g_lastBlockChainInfo = &RpcReplyGetblockchaininfo{}
 	g_lastTime = time.Time{}
 	g_txidSeen = map[txid]struct{}{}
 	g_txList = nil
@@ -128,7 +128,7 @@ func getLightdInfoStub(ctx context.Context, method string, params []json.RawMess
 	step++
 	switch method {
 	case "getinfo":
-		r, _ := json.Marshal(&ZcashdRpcReplyGetinfo{})
+		r, _ := json.Marshal(&RpcReplyGetinfo{})
 		return r, nil
 
 	case "getblockchaininfo":
@@ -141,7 +141,7 @@ func getLightdInfoStub(ctx context.Context, method string, params []json.RawMess
 				testT.Error("unexpected sleeps", sleepCount, sleepDuration)
 			}
 		}
-		r, _ := json.Marshal(&ZcashdRpcReplyGetblockchaininfo{
+		r, _ := json.Marshal(&RpcReplyGetblockchaininfo{
 			Blocks:    9977,
 			Chain:     "bugsbunny",
 			Consensus: ConsensusInfo{Chaintip: "someid"},
@@ -173,7 +173,7 @@ func TestGetLightdInfo(t *testing.T) {
 	RawRequest = getLightdInfoStub
 	defer resetGlobals()
 	Time.Sleep = sleepStub
-	// This calls the getblockchaininfo rpc just to establish connectivity with zcashd
+	// This calls the getblockchaininfo rpc just to establish connectivity with the node
 	FirstRPC()
 
 	DonationAddress = "ua1234test"
@@ -664,7 +664,7 @@ func TestGenerateCerts(t *testing.T) {
 
 // ------------------------------------------ GetMempoolStream
 
-// Note that in mocking zcashd's RPC replies here, we don't really need
+// Note that in mocking the node's RPC replies here, we don't really need
 // actual txids or transactions, or even strings with the correct format
 // for those, except that a transaction must be a hex string.
 func mempoolStub(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
@@ -675,7 +675,7 @@ func mempoolStub(ctx context.Context, method string, params []json.RawMessage) (
 		if method != "getblockchaininfo" {
 			testT.Fatal("expecting blockchaininfo")
 		}
-		r, _ := json.Marshal(&ZcashdRpcReplyGetblockchaininfo{
+		r, _ := json.Marshal(&RpcReplyGetblockchaininfo{
 			BestBlockHash: "010203",
 			Blocks:        200,
 		})
@@ -685,7 +685,7 @@ func mempoolStub(ctx context.Context, method string, params []json.RawMessage) (
 		if method != "getblockchaininfo" {
 			testT.Fatal("expecting blockchaininfo")
 		}
-		r, _ := json.Marshal(&ZcashdRpcReplyGetblockchaininfo{
+		r, _ := json.Marshal(&RpcReplyGetblockchaininfo{
 			BestBlockHash: "010203",
 			Blocks:        200,
 		})
@@ -717,7 +717,7 @@ func mempoolStub(ctx context.Context, method string, params []json.RawMessage) (
 		if method != "getblockchaininfo" {
 			testT.Fatal("expecting blockchaininfo")
 		}
-		r, _ := json.Marshal(&ZcashdRpcReplyGetblockchaininfo{
+		r, _ := json.Marshal(&RpcReplyGetblockchaininfo{
 			BestBlockHash: "010203",
 			Blocks:        200,
 		})
@@ -749,7 +749,7 @@ func mempoolStub(ctx context.Context, method string, params []json.RawMessage) (
 		if method != "getblockchaininfo" {
 			testT.Fatal("expecting blockchaininfo")
 		}
-		r, _ := json.Marshal(&ZcashdRpcReplyGetblockchaininfo{
+		r, _ := json.Marshal(&RpcReplyGetblockchaininfo{
 			BestBlockHash: "d1d2d3",
 			Blocks:        201,
 		})
@@ -811,12 +811,12 @@ func TestMempoolStream(t *testing.T) {
 		t.Fatal("unexpected end time")
 	}
 	if step != 8 {
-		t.Fatal("unexpected number of zebrad RPCs")
+		t.Fatal("unexpected number of node RPCs")
 	}
 }
 
-func TestZcashdRpcReplyUnmarshalling(t *testing.T) {
-	var txinfo0 ZcashdRpcReplyGetrawtransaction
+func TestRpcReplyUnmarshalling(t *testing.T) {
+	var txinfo0 RpcReplyGetrawtransaction
 	err0 := json.Unmarshal([]byte("{\"hex\": \"deadbeef\", \"height\": 123456}"), &txinfo0)
 	if err0 != nil {
 		t.Fatal("Failed to unmarshal tx with known height.")
@@ -825,7 +825,7 @@ func TestZcashdRpcReplyUnmarshalling(t *testing.T) {
 		t.Errorf("Unmarshalled incorrect height: got: %d, want: 123456.", txinfo0.Height)
 	}
 
-	var txinfo1 ZcashdRpcReplyGetrawtransaction
+	var txinfo1 RpcReplyGetrawtransaction
 	err1 := json.Unmarshal([]byte("{\"hex\": \"deadbeef\", \"height\": -1}"), &txinfo1)
 	if err1 != nil {
 		t.Fatal("failed to unmarshal tx not in main chain")
@@ -834,7 +834,7 @@ func TestZcashdRpcReplyUnmarshalling(t *testing.T) {
 		t.Errorf("Unmarshalled incorrect height: got: %d, want: -1.", txinfo1.Height)
 	}
 
-	var txinfo2 ZcashdRpcReplyGetrawtransaction
+	var txinfo2 RpcReplyGetrawtransaction
 	err2 := json.Unmarshal([]byte("{\"hex\": \"deadbeef\"}"), &txinfo2)
 	if err2 != nil {
 		t.Fatal("failed to unmarshal reply lacking height data")
@@ -885,7 +885,7 @@ func TestMempoolStreamCancelOnEmptyMempool(t *testing.T) {
 	RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
 		switch method {
 		case "getblockchaininfo":
-			r, _ := json.Marshal(&ZcashdRpcReplyGetblockchaininfo{
+			r, _ := json.Marshal(&RpcReplyGetblockchaininfo{
 				BestBlockHash: "stable-hash",
 				Blocks:        100,
 			})
@@ -906,7 +906,7 @@ func TestMempoolStreamCancelOnEmptyMempool(t *testing.T) {
 	// Pre-populate the package-global tip cache so the first refresh matches
 	// the stubbed tip and does NOT trigger the tip-changed branch (which
 	// would break out of the loop immediately).
-	g_lastBlockChainInfo = &ZcashdRpcReplyGetblockchaininfo{BestBlockHash: "stable-hash"}
+	g_lastBlockChainInfo = &RpcReplyGetblockchaininfo{BestBlockHash: "stable-hash"}
 	g_lastTime = time.Time{}
 	g_txidSeen = map[txid]struct{}{}
 	g_txList = []*walletrpc.RawTransaction{}

--- a/common/darkside.go
+++ b/common/darkside.go
@@ -28,7 +28,7 @@ type darksideState struct {
 	cache       *BlockCache
 
 	// This is the highest (latest) block height currently being presented
-	// by the mock zcashd.
+	// by the mock Zcash node.
 	latestHeight int
 
 	// Size of the Sapling commitment tree as of `startHeight - 1`.
@@ -38,9 +38,9 @@ type darksideState struct {
 	// Size of the Ironwood commitment tree as of `startHeight - 1`.
 	startIronwoodTreeSize uint32
 
-	// These blocks (up to and including tip) are presented by mock zcashd.
+	// These blocks (up to and including tip) are presented by the mock Zcash node.
 	// activeBlocks[0] is the block at height startHeight.
-	activeBlocks []*activeBlock // full blocks, binary, as from zcashd getblock rpc
+	activeBlocks []*activeBlock // full blocks, binary, as from the getblock rpc
 
 	// Staged blocks are waiting to be applied (by ApplyStaged()) to activeBlocks.
 	// They are in order of arrival (not necessarily sorted by height), and are
@@ -57,7 +57,7 @@ type darksideState struct {
 	stagedTransactions []stagedTx
 
 	// Unordered list of replies
-	getAddressUtxos []ZcashdRpcReplyGetaddressutxos
+	getAddressUtxos []RpcReplyGetaddressutxos
 
 	// List of (address, transaction, height) tuples for getaddresstxids
 	getAddressTransactions []*walletrpc.DarksideAddressTransaction
@@ -530,7 +530,7 @@ func darksideRawRequest(method string, params []json.RawMessage) (json.RawMessag
 		block := parser.NewBlock()
 		block.ParseFromSlice(state.activeBlocks[index].bytes)
 		hash := block.GetDisplayHashString()
-		blockchaininfo := &ZcashdRpcReplyGetblockchaininfo{
+		blockchaininfo := &RpcReplyGetblockchaininfo{
 			Chain: state.chainName,
 			Upgrades: map[string]Upgradeinfo{
 				"76b809bb": {ActivationHeight: state.startHeight},
@@ -542,7 +542,7 @@ func darksideRawRequest(method string, params []json.RawMessage) (json.RawMessag
 		return json.Marshal(blockchaininfo)
 
 	case "getinfo":
-		info := &ZcashdRpcReplyGetinfo{
+		info := &RpcReplyGetinfo{
 			Build:      "darksidewallet-build",
 			Subversion: "darksidewallet-subversion",
 		}
@@ -641,7 +641,7 @@ func darksideRawRequest(method string, params []json.RawMessage) (json.RawMessag
 		return json.Marshal(block.GetDisplayHashString())
 
 	case "getaddresstxids":
-		var req ZcashdRpcRequestGetaddresstxids
+		var req RpcRequestGetaddresstxids
 		err := json.Unmarshal(params[0], &req)
 		if err != nil {
 			return nil, errors.New("failed to parse getaddresstxids JSON")
@@ -716,12 +716,12 @@ func darksideRawRequest(method string, params []json.RawMessage) (json.RawMessag
 		return json.Marshal(reply)
 
 	case "getaddressutxos":
-		var req ZcashdRpcRequestGetaddressutxos
+		var req RpcRequestGetaddressutxos
 		err := json.Unmarshal(params[0], &req)
 		if err != nil {
 			return nil, errors.New("failed to parse getaddressutxos JSON")
 		}
-		utxosReply := make([]ZcashdRpcReplyGetaddressutxos, 0)
+		utxosReply := make([]RpcReplyGetaddressutxos, 0)
 		for _, utxo := range state.getAddressUtxos {
 			if slices.Contains(req.Addresses, utxo.Address) {
 				utxosReply = append(utxosReply, utxo)
@@ -752,22 +752,22 @@ func darksideRawRequest(method string, params []json.RawMessage) (json.RawMessag
 					"Stage it using AddTreeState() first"))
 		}
 
-		zcashdTreeState := &ZcashdRpcReplyGettreestate{}
+		treeStateReply := &RpcReplyGettreestate{}
 
-		zcashdTreeState.Hash = treeState.Hash
-		zcashdTreeState.Height = int(treeState.Height)
-		zcashdTreeState.Time = treeState.Time
-		zcashdTreeState.Sapling.Commitments.FinalState = treeState.SaplingTree
+		treeStateReply.Hash = treeState.Hash
+		treeStateReply.Height = int(treeState.Height)
+		treeStateReply.Time = treeState.Time
+		treeStateReply.Sapling.Commitments.FinalState = treeState.SaplingTree
 
 		if treeState.OrchardTree != "" {
-			zcashdTreeState.Orchard.Commitments.FinalState = treeState.OrchardTree
+			treeStateReply.Orchard.Commitments.FinalState = treeState.OrchardTree
 		}
 
 		if treeState.IronwoodTree != "" {
-			zcashdTreeState.Ironwood.Commitments.FinalState = treeState.IronwoodTree
+			treeStateReply.Ironwood.Commitments.FinalState = treeState.IronwoodTree
 		}
 
-		return json.Marshal(zcashdTreeState)
+		return json.Marshal(treeStateReply)
 
 	case "z_getsubtreesbyindex":
 		// This is implemented by DarksideGetSubtreeRoots().
@@ -966,7 +966,7 @@ func DarksideStageTransactionsURL(height int, url string) error {
 	return scan.Err()
 }
 
-func DarksideAddAddressUtxo(arg ZcashdRpcReplyGetaddressutxos) error {
+func DarksideAddAddressUtxo(arg RpcReplyGetaddressutxos) error {
 	mutex.Lock()
 	state.getAddressUtxos = append(state.getAddressUtxos, arg)
 	mutex.Unlock()

--- a/common/darkside_test.go
+++ b/common/darkside_test.go
@@ -140,7 +140,7 @@ func TestDarksideClearAllTreeStatesClearsHashIndex(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var treeState ZcashdRpcReplyGettreestate
+	var treeState RpcReplyGettreestate
 	if err := json.Unmarshal(result, &treeState); err != nil {
 		t.Fatal(err)
 	}

--- a/common/mempool.go
+++ b/common/mempool.go
@@ -13,7 +13,7 @@ type txid string
 
 var (
 	// Set of mempool txids that have been seen during the current block interval.
-	// The zcashd RPC `getrawmempool` returns the entire mempool each time, so
+	// The `getrawmempool` RPC returns the entire mempool each time, so
 	// this allows us to ignore the txids that we've already seen.
 	g_txidSeen map[txid]struct{} = map[txid]struct{}{}
 
@@ -27,9 +27,9 @@ var (
 	// (tip) block hash (so we know when a new block has been mined).
 	g_lastTime time.Time
 
-	// The most recent zcashd getblockchaininfo reply, for height and best block
+	// The most recent getblockchaininfo reply, for height and best block
 	// hash (tip) which is used to detect when a new block arrives.
-	g_lastBlockChainInfo *ZcashdRpcReplyGetblockchaininfo = &ZcashdRpcReplyGetblockchaininfo{}
+	g_lastBlockChainInfo *RpcReplyGetblockchaininfo = &RpcReplyGetblockchaininfo{}
 
 	// Mutex to protect the above variables.
 	g_lock sync.Mutex

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ A **compact block** is a collection of compact transactions along with certain m
 
 ```
 +----------+
-|  zcashd  |                       +----------+    +-------+
+|   node   |                       +----------+    +-------+
 +----+-----+              +------->+ frontend +--->+       |
      |                    |        +----------+    |  L    +<----Client
      | raw blocks    +----+----+                   |  O B  |
@@ -29,7 +29,7 @@ A **compact block** is a collection of compact transactions along with certain m
 
 The ingester is the component responsible for transforming raw Zcash block data into a compact block.
 
-The ingester is a modular component. Anything that can retrieve the necessary data and put it into storage can fulfill this role. Currently, the only ingester available communicated to zcashd through RPCs and parses that raw block data. 
+The ingester is a modular component. Anything that can retrieve the necessary data and put it into storage can fulfill this role. Currently, the only ingester available communicates to the Zcash node through RPCs and parses that raw block data. 
 
 **How do I run it?**
 
@@ -44,7 +44,7 @@ Now clone this repo and start the ingester. The first run will start slow as Go 
 ```
 $ git clone https://github.com/zcash/lightwalletd
 $ cd lightwalletd
-$ go run cmd/ingest/main.go --conf-file <path_to_zcash.conf> --db-path <path_to_sqllightdb>
+$ go run cmd/ingest/main.go --conf-file <path_to_node_conf> --db-path <path_to_sqllightdb>
 ```
 
 To see the other command line options, run `go run cmd/ingest/main.go --help`.
@@ -79,7 +79,7 @@ x509 Certificates! This software relies on the confidentiality and integrity of 
 
 Otherwise, not much! This is a very simple piece of software. Make sure you point it at the same storage as the ingester. See the "Production" section for some caveats.
 
-Support for users sending transactions will require the ability to make JSON-RPC calls to a zcashd instance. By default the frontend tries to pull RPC credentials from your zcashd.conf file, but you can specify other credentials via command line flag. In the future, it should be possible to do this with environment variables [(#2)](https://github.com/zcash/lightwalletd/issues/2).
+Support for users sending transactions will require the ability to make JSON-RPC calls to a Zcash node. By default the frontend tries to pull the RPC address and credentials from your node's config file, but you can specify other credentials via command line flag. In the future, it should be possible to do this with environment variables [(#2)](https://github.com/zcash/lightwalletd/issues/2).
 
 ## Storage
 

--- a/docs/darksidewalletd.md
+++ b/docs/darksidewalletd.md
@@ -3,7 +3,7 @@
 Darksidewalletd is a feature included in lightwalletd, enabled by the
 `--darkside-very-insecure` flag, which can serve arbitrary blocks to a Zcash
 light client wallet. This is useful for security and reorg testing. It includes
-a minimally-functional mock zcashd which comes with a gRPC API for controlling
+a minimally-functional mock Zcash node which comes with a gRPC API for controlling
 which blocks it will serve.
 
 This means that you can use darksidewalletd to control the blocks and
@@ -26,8 +26,8 @@ mitigates these risks, but users should still be cautious.
 ## Dependencies 
 
 Lightwalletd and most dependencies of lightwalletd, including Go version 1.11 or
-later, but not zcashd. Since Darksidewalletd mocks zcashd, it can run standalone
-and does not use zcashd to get blocks or send and receive transactions.
+later. Since Darksidewalletd mocks the backend node, it can run standalone
+and does not use a Zcash node to get blocks or send and receive transactions.
 
 For the tutorial the `grpcurl` tool is needed to call the `darksidewalletd`
 gRPC API.

--- a/docs/rtd/index.html
+++ b/docs/rtd/index.html
@@ -1187,21 +1187,21 @@ relevant to the shielded (Sapling, Orchard, and Ironwood) pools. </p></td>
                   <td>estimatedHeight</td>
                   <td><a href="#uint64">uint64</a></td>
                   <td></td>
-                  <td><p>less than tip height if zcashd is syncing </p></td>
+                  <td><p>less than tip height if the node is syncing </p></td>
                 </tr>
               
                 <tr>
                   <td>zcashdBuild</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p>example: &#34;v4.1.1-877212414&#34; </p></td>
+                  <td><p>the backend node build string, e.g. &#34;2.5.0&#34; </p></td>
                 </tr>
               
                 <tr>
                   <td>zcashdSubversion</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p>example: &#34;/MagicBean:4.1.1/&#34; </p></td>
+                  <td><p>example: &#34;/Zebra:2.5.0/&#34; </p></td>
                 </tr>
               
                 <tr>
@@ -1294,11 +1294,11 @@ relevant to the shielded (Sapling, Orchard, and Ironwood) pools. </p></td>
                   <td><p>The height at which the transaction is mined, or a sentinel value.
 
 Due to an error in the original protobuf definition, it is necessary to
-reinterpret the result of the `getrawtransaction` RPC call. Zcashd will
+reinterpret the result of the `getrawtransaction` RPC call. The node will
 return the int64 value `-1` for the height of transactions that appear
 in the block index, but which are not mined in the main chain. Here, the
 height field of `RawTransaction` was erroneously created as a `uint64`,
-and as such we must map the response from the zcashd RPC API to be
+and as such we must map the response from the node&#39;s RPC API to be
 representable within this space. Additionally, the `height` field will
 be absent for transactions in the mempool, resulting in the default
 value of `0` being set. Therefore, the meanings of the `height` field of
@@ -1676,7 +1676,7 @@ appropriate `poolTypes` instead.</p></td>
                 <td>GetTransaction</td>
                 <td><a href="#cash.z.wallet.sdk.rpc.TxFilter">TxFilter</a></td>
                 <td><a href="#cash.z.wallet.sdk.rpc.RawTransaction">RawTransaction</a></td>
-                <td><p>Return the requested full (not compact) transaction (as from zcashd)</p></td>
+                <td><p>Return the requested full (not compact) transaction (as from the node)</p></td>
               </tr>
             
               <tr>

--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -52,7 +52,7 @@ func testsetup() (walletrpc.CompactTxStreamerServer, *common.BlockCache) {
 	return lwd, cache
 }
 
-// resetGlobals restores the package globals that tests replace -- the zcashd
+// resetGlobals restores the package globals that tests replace -- the node
 // RPC stub and the step counter those stubs sequence through -- to the values
 // they have at package initialization. Any test that installs a stub should
 // "defer resetGlobals()" so it doesn't leak into later tests, even if the test
@@ -215,7 +215,7 @@ func TestGetLatestBlock(t *testing.T) {
 	// This argument is not used (it may be in the future)
 	req := &walletrpc.ChainSpec{}
 
-	// This does zcashd rpc "getblock", calls getLatestBlockStub() above
+	// This does the node rpc "getblock", calls getLatestBlockStub() above
 	block, err := common.GetBlock(context.Background(), cache, 380640)
 	if err != nil {
 		t.Fatal("getBlockFromRPC failed", err)
@@ -250,11 +250,11 @@ var addressTests = []string{
 	"t1234567890123456789012345678901234\n", // newline after
 }
 
-func zcashdrpcStub(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
+func nodeRPCStub(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
 	step++
 	switch method {
 	case "getaddresstxids":
-		var filter common.ZcashdRpcRequestGetaddresstxids
+		var filter common.RpcRequestGetaddresstxids
 		err := json.Unmarshal(params[0], &filter)
 		if err != nil {
 			testT.Fatal("could not unmarshal block filter")
@@ -275,7 +275,7 @@ func zcashdrpcStub(ctx context.Context, method string, params []json.RawMessage)
 	case "getrawtransaction":
 		switch step {
 		case 2:
-			tx := &common.ZcashdRpcReplyGetrawtransaction{
+			tx := &common.RpcReplyGetrawtransaction{
 				Hex:    hex.EncodeToString(rawTxData[0]),
 				Height: 1234567,
 			}
@@ -285,7 +285,7 @@ func zcashdrpcStub(ctx context.Context, method string, params []json.RawMessage)
 			return []byte(""), errors.New("-5: test getrawtransaction error")
 		}
 	}
-	testT.Fatal("unexpected call to zcashdrpcStub")
+	testT.Fatal("unexpected call to nodeRPCStub")
 	return nil, nil
 }
 
@@ -318,16 +318,16 @@ func (t *testtaddrbalance) SendAndClose(b *walletrpc.Balance) error {
 }
 
 // getaddressbalanceStub returns a fixed balance and asserts that the request
-// only reaches zcashd with the expected (valid, bounded) address list.
+// only reaches the node with the expected (valid, bounded) address list.
 func getaddressbalanceStub(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
 	if method != "getaddressbalance" {
 		testT.Fatal("unexpected method", method)
 	}
-	var req common.ZcashdRpcRequestGetaddressbalance
+	var req common.RpcRequestGetaddressbalance
 	if err := json.Unmarshal(params[0], &req); err != nil {
 		testT.Fatal("could not unmarshal getaddressbalance request")
 	}
-	return json.Marshal(common.ZcashdRpcReplyGetaddressbalance{Balance: 1234})
+	return json.Marshal(common.RpcReplyGetaddressbalance{Balance: 1234})
 }
 
 func TestGetTaddressBalanceStream(t *testing.T) {
@@ -337,10 +337,10 @@ func TestGetTaddressBalanceStream(t *testing.T) {
 
 	validAddr := "t1234567890123456789012345678901234"
 
-	// An invalid address must be rejected immediately, before any zcashd
+	// An invalid address must be rejected immediately, before any node
 	// call, and before the whole (potentially unbounded) stream is buffered.
 	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
-		testT.Fatal("zcashd must not be called for an invalid address")
+		testT.Fatal("the node must not be called for an invalid address")
 		return nil, nil
 	}
 	{
@@ -371,7 +371,7 @@ func TestGetTaddressBalanceStream(t *testing.T) {
 		}
 	}
 
-	// A valid, bounded request succeeds and returns the balance from zcashd.
+	// A valid, bounded request succeeds and returns the balance from the node.
 	common.RawRequest = getaddressbalanceStub
 	{
 		mock := &testtaddrbalance{addrs: []string{validAddr, validAddr}}
@@ -390,11 +390,11 @@ func TestGetAddressUtxosTooManyAddresses(t *testing.T) {
 	defer resetGlobals()
 	lwd, _ := testsetup()
 
-	// A request naming too many addresses must be rejected before zcashd is
+	// A request naming too many addresses must be rejected before the node is
 	// contacted, so one request can't force unbounded backend work
 	// (GHSA-x4m7-3gpp-xc36).
 	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
-		testT.Fatal("zcashd must not be called when the address list is over the limit")
+		testT.Fatal("the node must not be called when the address list is over the limit")
 		return nil, nil
 	}
 	addrs := make([]string, maxTaddrsPerRequest+1)
@@ -430,7 +430,7 @@ func (tg *testgettx) Send(tx *walletrpc.RawTransaction) error {
 
 func TestGetTaddressTransactions(t *testing.T) {
 	testT = t
-	common.RawRequest = zcashdrpcStub
+	common.RawRequest = nodeRPCStub
 	defer resetGlobals()
 	lwd, _ := testsetup()
 
@@ -516,9 +516,9 @@ func TestGetTaddressTransactionsDefaultsEndToTip(t *testing.T) {
 	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
 		switch method {
 		case "getblockchaininfo":
-			return json.Marshal(common.ZcashdRpcReplyGetblockchaininfo{Blocks: tip})
+			return json.Marshal(common.RpcReplyGetblockchaininfo{Blocks: tip})
 		case "getaddresstxids":
-			var filter common.ZcashdRpcRequestGetaddresstxids
+			var filter common.RpcRequestGetaddresstxids
 			if err := json.Unmarshal(params[0], &filter); err != nil {
 				testT.Fatal("could not unmarshal getaddresstxids request")
 			}
@@ -543,7 +543,7 @@ func TestGetTaddressTransactionsDefaultsEndToTip(t *testing.T) {
 	}
 }
 
-// A range wider than maxTaddrTxBlockSpan must be rejected before zcashd is
+// A range wider than maxTaddrTxBlockSpan must be rejected before the node is
 // contacted (GHSA-x4m7-3gpp-xc36 F2).
 func TestGetTaddressTransactionsRangeTooWide(t *testing.T) {
 	testT = t
@@ -551,7 +551,7 @@ func TestGetTaddressTransactionsRangeTooWide(t *testing.T) {
 	lwd, _ := testsetup()
 
 	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
-		testT.Fatal("zcashd must not be called when the range is too wide")
+		testT.Fatal("the node must not be called when the range is too wide")
 		return nil, nil
 	}
 	filter := &walletrpc.TransparentAddressBlockFilter{
@@ -845,7 +845,7 @@ func TestPruneCompactBlockToNullifiers(t *testing.T) {
 
 // An explicit End of height 0 must not be treated as "no bound": `End` carries
 // `json:",omitempty"`, so a zero value is dropped from the getaddresstxids
-// request and zcashd falls back to an open-ended scan — the exact behaviour
+// request and the node falls back to an open-ended scan — the exact behaviour
 // GHSA-x4m7-3gpp-xc36 F2 is meant to prevent.
 func TestGetTaddressTransactionsZeroEndIsBounded(t *testing.T) {
 	testT = t
@@ -856,9 +856,9 @@ func TestGetTaddressTransactionsZeroEndIsBounded(t *testing.T) {
 	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
 		switch method {
 		case "getblockchaininfo":
-			return json.Marshal(common.ZcashdRpcReplyGetblockchaininfo{Blocks: tip})
+			return json.Marshal(common.RpcReplyGetblockchaininfo{Blocks: tip})
 		case "getaddresstxids":
-			var filter common.ZcashdRpcRequestGetaddresstxids
+			var filter common.RpcRequestGetaddresstxids
 			if err := json.Unmarshal(params[0], &filter); err != nil {
 				testT.Fatal("could not unmarshal getaddresstxids request")
 			}
@@ -885,14 +885,14 @@ func TestGetTaddressTransactionsZeroEndIsBounded(t *testing.T) {
 
 // An invalid-length block hash must be rejected before it is hex-expanded and
 // forwarded, so a client can't force large allocations here or parsing work in
-// zcashd with input that can only ever be rejected (GHSA-q2c2-hpp9-58hm).
+// the node with input that can only ever be rejected (GHSA-q2c2-hpp9-58hm).
 func TestGetTreeStateInvalidHashLength(t *testing.T) {
 	testT = t
 	defer resetGlobals()
 	lwd, _ := testsetup()
 
 	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
-		testT.Fatal("zcashd must not be called for an invalid-length block hash")
+		testT.Fatal("the node must not be called for an invalid-length block hash")
 		return nil, nil
 	}
 	for _, n := range []int{1, 31, 33, 64, 4 << 20} {
@@ -906,7 +906,7 @@ func TestGetTreeStateInvalidHashLength(t *testing.T) {
 		}
 	}
 
-	// A correctly-sized hash must still reach zcashd -- the guard must not
+	// A correctly-sized hash must still reach the node -- the guard must not
 	// reject valid input.
 	forwarded := false
 	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
@@ -922,7 +922,7 @@ func TestGetTreeStateInvalidHashLength(t *testing.T) {
 		t.Fatal("expected the stubbed backend error")
 	}
 	if !forwarded {
-		t.Fatal("a 32-byte hash should have been forwarded to zcashd")
+		t.Fatal("a 32-byte hash should have been forwarded to the node")
 	}
 }
 
@@ -934,9 +934,9 @@ func TestSendTransactionOversized(t *testing.T) {
 	defer resetGlobals()
 	lwd, _ := testsetup()
 
-	// Over the limit: rejected locally, zcashd never contacted.
+	// Over the limit: rejected locally, the node never contacted.
 	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
-		testT.Fatal("zcashd must not be called for an oversized transaction")
+		testT.Fatal("the node must not be called for an oversized transaction")
 		return nil, nil
 	}
 	_, err := lwd.SendTransaction(context.Background(),
@@ -948,7 +948,7 @@ func TestSendTransactionOversized(t *testing.T) {
 		t.Fatal("expected InvalidArgument on oversized transaction, got:", err)
 	}
 
-	// Exactly at the limit: forwarded to zcashd.
+	// Exactly at the limit: forwarded to the node.
 	forwarded := false
 	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
 		forwarded = true
@@ -989,9 +989,9 @@ func TestGetMempoolTxExcludeListCap(t *testing.T) {
 		suffixes[i] = []byte{1, 2, 3, 4}
 	}
 
-	// Over the cap: rejected locally, zcashd never contacted.
+	// Over the cap: rejected locally, the node never contacted.
 	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
-		testT.Fatal("zcashd must not be called for an oversized exclude list")
+		testT.Fatal("the node must not be called for an oversized exclude list")
 		return nil, nil
 	}
 	err := lwd.GetMempoolTx(

--- a/frontend/rawrequest.go
+++ b/frontend/rawrequest.go
@@ -69,11 +69,11 @@ func newContextHTTPClient(cfg *rpcclient.ConnConfig) (*http.Client, error) {
 	}, nil
 }
 
-// NewContextRawRequest returns a context-aware JSON-RPC function for zcashd and
-// zebrad. It is a port of btcsuite/btcd/rpcclient's HTTP POST path (same retry
+// NewContextRawRequest returns a context-aware JSON-RPC function for
+// the Zcash node. It is a port of btcsuite/btcd/rpcclient's HTTP POST path (same retry
 // count, backoff schedule, and per-request connection handling) with ctx threaded
 // through via http.NewRequestWithContext, so that a cancelled gRPC stream aborts
-// the in-flight request instead of leaking a goroutine and a zcashd RPC slot.
+// the in-flight request instead of leaking a goroutine and a node RPC slot.
 //
 // This wrapper exists only because btcd's rpcclient does not yet expose a
 // context-aware request method. Once btcsuite/btcd#2506 (RawRequestWithContext)

--- a/frontend/rawrequest_test.go
+++ b/frontend/rawrequest_test.go
@@ -58,7 +58,7 @@ func TestContextRawRequestSuccess(t *testing.T) {
 }
 
 // TestContextRawRequestCancel verifies that cancelling the context aborts an
-// in-flight request promptly, rather than blocking until the zcashd RPC returns.
+// in-flight request promptly, rather than blocking until the node RPC returns.
 // This is the core guarantee of the fix for GHSA-5h96-xw2v-jxgq.
 func TestContextRawRequestCancel(t *testing.T) {
 	var once sync.Once

--- a/frontend/rpc_client.go
+++ b/frontend/rpc_client.go
@@ -16,7 +16,12 @@ import (
 	ini "gopkg.in/ini.v1"
 )
 
-// ConnConfigFromConf reads the zcashd configuration file.
+// ConnConfigFromConf reads a config file describing how to reach the Zcash
+// node's RPC interface: either TOML (.toml extension) or zcash.conf-style INI.
+// Note that a node's own config file (e.g. zebrad.toml) is generally not
+// suitable here: its RPC listen address is the node's bind address, which is
+// not necessarily an address that lightwalletd can reach. Prefer the
+// --rpchost, --rpcport, --rpcuser, and --rpcpassword options instead.
 func ConnConfigFromConf(confPath string) (*rpcclient.ConnConfig, error) {
 	return connFromConf(confPath)
 }
@@ -27,23 +32,9 @@ func ConnConfigFromFlags(opts *common.Options) *rpcclient.ConnConfig {
 		Host:         net.JoinHostPort(opts.RPCHost, opts.RPCPort),
 		User:         opts.RPCUser,
 		Pass:         opts.RPCPassword,
-		HTTPPostMode: true, // Zcash only supports HTTP POST mode
-		DisableTLS:   true, // Zcash does not provide TLS by default
+		HTTPPostMode: true, // the node RPC only supports HTTP POST mode
+		DisableTLS:   true, // the node RPC does not provide TLS by default
 	}
-}
-
-// NewZRPCFromConf reads the zcashd configuration file.
-func NewZRPCFromConf(confPath string) (*rpcclient.Client, error) {
-	connCfg, err := ConnConfigFromConf(confPath)
-	if err != nil {
-		return nil, err
-	}
-	return rpcclient.New(connCfg, nil)
-}
-
-// NewZRPCFromFlags gets zcashd rpc connection information from provided flags.
-func NewZRPCFromFlags(opts *common.Options) (*rpcclient.Client, error) {
-	return rpcclient.New(ConnConfigFromFlags(opts), nil)
 }
 
 func connFromConf(confPath string) (*rpcclient.ConnConfig, error) {
@@ -54,6 +45,8 @@ func connFromConf(confPath string) (*rpcclient.ConnConfig, error) {
 	}
 }
 
+// Read a zcash.conf-style INI config file to find the RPC address and
+// credentials of the Zcash node.
 func connFromIni(confPath string) (*rpcclient.ConnConfig, error) {
 	cfg, err := ini.Load(confPath)
 	if err != nil {
@@ -77,24 +70,24 @@ func connFromIni(confPath string) (*rpcclient.ConnConfig, error) {
 	password := cfg.Section("").Key("rpcpassword").String()
 
 	if password == "" {
-		return nil, errors.New("rpcpassword not found (or empty), please add rpcpassword= to zcash.conf")
+		return nil, errors.New("rpcpassword not found (or empty), please add rpcpassword= to the config file")
 	}
 
-	// Connect to local Zcash RPC server using HTTP POST mode.
+	// Connect to the node's RPC server using HTTP POST mode.
 	connCfg := &rpcclient.ConnConfig{
 		Host:         net.JoinHostPort(rpcaddr, rpcport),
 		User:         username,
 		Pass:         password,
-		HTTPPostMode: true, // Zcash only supports HTTP POST mode
-		DisableTLS:   true, // Zcash does not provide TLS by default
+		HTTPPostMode: true, // the node RPC only supports HTTP POST mode
+		DisableTLS:   true, // the node RPC does not provide TLS by default
 	}
 	// Notice the notification parameter is nil since notifications are
 	// not supported in HTTP POST mode.
 	return connCfg, nil
 }
 
-// If passed a string, interpret as a path, open and read; if passed
-// a byte slice, interpret as the config file content (used in testing).
+// Read a TOML config file containing an [rpc] table (listen_addr, rpcuser,
+// rpcpassword) to find the RPC address and credentials of the Zcash node.
 func connFromToml(confPath string) (*rpcclient.ConnConfig, error) {
 	var tomlConf struct {
 		Rpc struct {
@@ -111,8 +104,8 @@ func connFromToml(confPath string) (*rpcclient.ConnConfig, error) {
 		Host:         tomlConf.Rpc.Listen_addr,
 		User:         tomlConf.Rpc.RPCUser,
 		Pass:         tomlConf.Rpc.RPCPassword,
-		HTTPPostMode: true, // Zcash only supports HTTP POST mode
-		DisableTLS:   true, // Zcash does not provide TLS by default
+		HTTPPostMode: true, // the node RPC only supports HTTP POST mode
+		DisableTLS:   true, // the node RPC does not provide TLS by default
 	}
 
 	// Notice the notification parameter is nil since notifications are

--- a/frontend/service.go
+++ b/frontend/service.go
@@ -66,7 +66,7 @@ func checkTaddress(taddr string) error {
 	return nil
 }
 
-// GetLatestBlock returns the height and hash of the best chain, according to zcashd.
+// GetLatestBlock returns the height and hash of the best chain, according to the node.
 func (s *lwdStreamer) GetLatestBlock(ctx context.Context, placeholder *walletrpc.ChainSpec) (*walletrpc.BlockID, error) {
 	common.Log.Debugf("gRPC GetLatestBlock(%+v)\n", placeholder)
 
@@ -93,7 +93,7 @@ func (s *lwdStreamer) GetLatestBlock(ctx context.Context, placeholder *walletrpc
 // request may scan. It is deliberately generous -- well beyond a full-history
 // scan of the current chain -- so it never rejects a legitimate wallet request,
 // while still rejecting an absurd End (e.g. near uint64-max) that would
-// otherwise be forwarded to zcashd. Together with defaulting a missing End to
+// otherwise be forwarded to the node. Together with defaulting a missing End to
 // the chain tip, it keeps one request from requesting an unbounded
 // address-index scan (GHSA-x4m7-3gpp-xc36, finding 2).
 const maxTaddrTxBlockSpan = 10_000_000
@@ -115,7 +115,7 @@ func (s *lwdStreamer) GetTaddressTransactions(addressBlockFilter *walletrpc.Tran
 		return status.Error(codes.InvalidArgument, "GetTaddressTransactions: must specify a start block height")
 	}
 
-	// End is optional in the protocol. An unset End would make zcashd's
+	// End is optional in the protocol. An unset End would make the node's
 	// getaddresstxids scan the address index all the way to the current chain
 	// tip, with no upper bound as the chain grows; default it to the current tip
 	// so the scan is always to a concrete, finite height. Bound the span so one
@@ -125,7 +125,7 @@ func (s *lwdStreamer) GetTaddressTransactions(addressBlockFilter *walletrpc.Tran
 	var end uint64
 	// A zero End must be treated as unset, not as a bound: the getaddresstxids
 	// request field carries `json:",omitempty"`, so End=0 is dropped from the
-	// request entirely and zcashd falls back to the open-ended scan this is
+	// request entirely and the node falls back to the open-ended scan this is
 	// meant to prevent.
 	if addressBlockFilter.Range.End != nil && addressBlockFilter.Range.End.Height > 0 {
 		end = addressBlockFilter.Range.End.Height
@@ -143,7 +143,7 @@ func (s *lwdStreamer) GetTaddressTransactions(addressBlockFilter *walletrpc.Tran
 			end-start, maxTaddrTxBlockSpan)
 	}
 
-	request := &common.ZcashdRpcRequestGetaddresstxids{
+	request := &common.RpcRequestGetaddresstxids{
 		Addresses: []string{addressBlockFilter.Address},
 		Start:     start,
 		End:       end,
@@ -157,7 +157,7 @@ func (s *lwdStreamer) GetTaddressTransactions(addressBlockFilter *walletrpc.Tran
 	params := []json.RawMessage{param}
 
 	// Bound the total time -- and make the backend calls cancelable -- so a slow
-	// or abandoned scan doesn't hold a lightwalletd goroutine and a zcashd RPC
+	// or abandoned scan doesn't hold a lightwalletd goroutine and a node RPC
 	// connection open indefinitely. This deadline covers both the getaddresstxids
 	// index scan and the per-txid getrawtransaction fan-out below.
 	timeout, cancel := context.WithTimeout(resp.Context(), 30*time.Second)
@@ -372,7 +372,7 @@ func (s *lwdStreamer) GetTreeState(ctx context.Context, id *walletrpc.BlockID) (
 		params[0] = heightJSON
 	} else {
 		// Reject a wrong-length hash before expanding it: the bytes below are
-		// hex-encoded (doubling them) and JSON-marshalled before zcashd ever
+		// hex-encoded (doubling them) and JSON-marshalled before the node ever
 		// sees them, so without this an unauthenticated client can force large
 		// allocations here and parsing work in the backend with input that can
 		// only ever be rejected (GHSA-q2c2-hpp9-58hm).
@@ -390,13 +390,13 @@ func (s *lwdStreamer) GetTreeState(ctx context.Context, id *walletrpc.BlockID) (
 		}
 		params[0] = hashJSON
 	}
-	var gettreestateReply common.ZcashdRpcReplyGettreestate
+	var gettreestateReply common.RpcReplyGettreestate
 	for {
 		// Hygiene companion to PR #560: observe client cancel between
 		// RawRequest calls. In practice this loop terminates in one iteration
-		// on the active chain because zcashd's z_gettreestate hard-stops the
-		// SkipHash walk at the Sapling activation height (zcashd
-		// src/rpc/blockchain.cpp:1411). This check is for symmetry with the
+		// on the active chain because the node's z_gettreestate hard-stops the
+		// SkipHash walk at the Sapling activation height. This check is for
+		// symmetry with the
 		// other streaming-RPC ctx-checks, not for DoS defense.
 		if err := ctx.Err(); err != nil {
 			return nil, status.FromContextError(err).Err()
@@ -457,7 +457,7 @@ func (s *lwdStreamer) GetLatestTreeState(ctx context.Context, in *walletrpc.Empt
 }
 
 // GetTransaction returns the raw transaction bytes that are returned
-// by the zcashd 'getrawtransaction' RPC.
+// by the node's 'getrawtransaction' RPC.
 func (s *lwdStreamer) GetTransaction(ctx context.Context, txf *walletrpc.TxFilter) (*walletrpc.RawTransaction, error) {
 	common.Log.Debugf("gRPC GetTransaction(%+v)\n", txf)
 	if txf.Hash != nil {
@@ -498,7 +498,7 @@ func (s *lwdStreamer) GetTransaction(ctx context.Context, txf *walletrpc.TxFilte
 }
 
 // GetLightdInfo gets the LightWalletD (this server) info, and includes information
-// it gets from its backend zcashd.
+// it gets from its backend Zcash node.
 func (s *lwdStreamer) GetLightdInfo(ctx context.Context, in *walletrpc.Empty) (*walletrpc.LightdInfo, error) {
 	lightdinfo, err := common.GetLightdInfo()
 	if err != nil {
@@ -508,12 +508,12 @@ func (s *lwdStreamer) GetLightdInfo(ctx context.Context, in *walletrpc.Empty) (*
 }
 
 // maxRawTxSize bounds the raw transaction bytes lightwalletd will forward to
-// zcashd. A Zcash transaction cannot exceed the 2,000,000-byte block size
-// limit, so anything larger is unminable by definition and there is no reason
-// to spend memory expanding it or to make the backend parse it.
+// the Zcash node. A Zcash transaction cannot exceed the 2,000,000-byte block
+// size limit, so anything larger is unminable by definition and there is no
+// reason to spend memory expanding it or to make the backend parse it.
 const maxRawTxSize = 2000000
 
-// SendTransaction forwards raw transaction bytes to a zcashd instance over JSON-RPC
+// SendTransaction forwards raw transaction bytes to the Zcash node over JSON-RPC
 func (s *lwdStreamer) SendTransaction(ctx context.Context, rawtx *walletrpc.RawTransaction) (*walletrpc.SendResponse, error) {
 	common.Log.Debugf("gRPC SendTransaction(%+v)\n", rawtx)
 	// sendrawtransaction "hexstring" ( allowhighfees )
@@ -528,7 +528,7 @@ func (s *lwdStreamer) SendTransaction(ctx context.Context, rawtx *walletrpc.RawT
 		return nil, status.Error(codes.InvalidArgument, "bad transaction data")
 	}
 	// Reject an oversized transaction before expanding it: the bytes below are
-	// hex-encoded (doubling them) and JSON-marshalled before zcashd ever sees
+	// hex-encoded (doubling them) and JSON-marshalled before the node ever sees
 	// them, so without this an unauthenticated client can force large
 	// allocations here and parsing work in the backend with a transaction that
 	// can never be mined (GHSA-6ppp-r2gc-9q6v).
@@ -580,14 +580,14 @@ func (s *lwdStreamer) SendTransaction(ctx context.Context, rawtx *walletrpc.RawT
 	return r, nil
 }
 
-func getTaddressBalanceZcashdRpc(ctx context.Context, addressList []string) (*walletrpc.Balance, error) {
+func getTaddressBalanceRpc(ctx context.Context, addressList []string) (*walletrpc.Balance, error) {
 	for _, addr := range addressList {
 		if err := checkTaddress(addr); err != nil {
 			return nil, err
 		}
 	}
 	params := make([]json.RawMessage, 1)
-	addrList := &common.ZcashdRpcRequestGetaddressbalance{
+	addrList := &common.RpcRequestGetaddressbalance{
 		Addresses: addressList,
 	}
 	param, err := json.Marshal(addrList)
@@ -606,13 +606,13 @@ func getTaddressBalanceZcashdRpc(ctx context.Context, addressList []string) (*wa
 			code = codes.NotFound
 		}
 		return nil, status.Errorf(code,
-			"getTaddressBalanceZcashdRpc: getaddressbalance error: %s", rpcErr.Error())
+			"getTaddressBalanceRpc: getaddressbalance error: %s", rpcErr.Error())
 	}
-	var balanceReply common.ZcashdRpcReplyGetaddressbalance
+	var balanceReply common.RpcReplyGetaddressbalance
 	err = json.Unmarshal(result, &balanceReply)
 	if err != nil {
 		return nil, status.Errorf(codes.Unknown,
-			"getTaddressBalanceZcashdRpc: failed to unmarshal getaddressbalance reply, error: %s", err.Error())
+			"getTaddressBalanceRpc: failed to unmarshal getaddressbalance reply, error: %s", err.Error())
 	}
 	return &walletrpc.Balance{ValueZat: balanceReply.Balance}, nil
 }
@@ -620,7 +620,7 @@ func getTaddressBalanceZcashdRpc(ctx context.Context, addressList []string) (*wa
 // GetTaddressBalance returns the total balance for a list of taddrs
 func (s *lwdStreamer) GetTaddressBalance(ctx context.Context, addresses *walletrpc.AddressList) (*walletrpc.Balance, error) {
 	common.Log.Debugf("gRPC GetTaddressBalance(%+v)\n", addresses)
-	r, err := getTaddressBalanceZcashdRpc(ctx, addresses.Addresses)
+	r, err := getTaddressBalanceRpc(ctx, addresses.Addresses)
 	if err == nil {
 		common.Log.Tracef("  return: %+v\n", r)
 	}
@@ -632,7 +632,7 @@ func (s *lwdStreamer) GetTaddressBalance(ctx context.Context, addresses *walletr
 // gRPC methods. Without a cap, an unauthenticated client can drive unbounded
 // memory growth and backend work: GetTaddressBalanceStream accumulates
 // streamed addresses until the process is OOM-killed, and GetAddressUtxos
-// forwards the whole list to zcashd and materializes the full result before
+// forwards the whole list to the node and materializes the full result before
 // applying client-side limits. The unary GetTaddressBalance is already
 // implicitly bounded by gRPC's MaxRecvMsgSize; this gives the other methods an
 // equivalent bound, generous for any legitimate wallet (GHSA-x4m7-3gpp-xc36).
@@ -661,7 +661,7 @@ func (s *lwdStreamer) GetTaddressBalanceStream(addresses walletrpc.CompactTxStre
 		}
 		addressList = append(addressList, addr.Address)
 	}
-	balance, err := getTaddressBalanceZcashdRpc(addresses.Context(), addressList)
+	balance, err := getTaddressBalanceRpc(addresses.Context(), addressList)
 	if err != nil {
 		return err
 	}
@@ -686,13 +686,13 @@ var mempoolMap *map[string]*walletrpc.CompactTx
 // Txids in big-endian hex (from the backend)
 var mempoolList []string
 
-// Last time we pulled a copy of the mempool from zcashd.
+// Last time we pulled a copy of the mempool from the node.
 var lastMempool time.Time
 
 // maxExcludeTxidSuffixes bounds the exclude list a client may send to
 // GetMempoolTx. The list names transactions the caller already has, so it is
 // only ever useful up to the size of the mempool itself; this cap sits well
-// above the number of transactions zcashd's default mempool can hold.
+// above the number of transactions a node's default mempool can hold.
 const maxExcludeTxidSuffixes = 20000
 
 func (s *lwdStreamer) GetMempoolTx(exclude *walletrpc.GetMempoolTxRequest, resp walletrpc.CompactTxStreamer_GetMempoolTxServer) error {
@@ -702,7 +702,7 @@ func (s *lwdStreamer) GetMempoolTx(exclude *walletrpc.GetMempoolTxRequest, resp 
 	// allocate, hex-encode and sort all of it -- historically while holding
 	// s.mutex, and even when the mempool was empty and the response would be
 	// empty too (GHSA-4hp3-3494-3f2m). The cap is comfortably larger than the
-	// number of transactions zcashd's default mempool can hold, so an exclude
+	// number of transactions a node's default mempool can hold, so an exclude
 	// list beyond it cannot describe a useful set in any case.
 	if len(exclude.ExcludeTxidSuffixes) > maxExcludeTxidSuffixes {
 		return status.Errorf(codes.InvalidArgument,
@@ -870,7 +870,7 @@ func MempoolFilter(items, exclude []string) []string {
 }
 
 func getAddressUtxos(ctx context.Context, arg *walletrpc.GetAddressUtxosArg, f func(*walletrpc.GetAddressUtxosReply) error) error {
-	// Bound the address count before contacting zcashd: getaddressutxos cannot
+	// Bound the address count before contacting the node: getaddressutxos cannot
 	// push down StartHeight/MaxEntries, so lightwalletd fetches and
 	// materializes the entire backend result before applying those limits.
 	// Capping the input keeps one request from forcing unbounded backend work
@@ -884,7 +884,7 @@ func getAddressUtxos(ctx context.Context, arg *walletrpc.GetAddressUtxosArg, f f
 			return err
 		}
 	}
-	addrList := &common.ZcashdRpcRequestGetaddressutxos{
+	addrList := &common.RpcRequestGetaddressutxos{
 		Addresses: arg.Addresses,
 	}
 	param, err := json.Marshal(addrList)
@@ -905,7 +905,7 @@ func getAddressUtxos(ctx context.Context, arg *walletrpc.GetAddressUtxosArg, f f
 		return status.Errorf(code,
 			"getAddressUtxos: getaddressutxos error: %s", rpcErr.Error())
 	}
-	var utxosReply []common.ZcashdRpcReplyGetaddressutxos
+	var utxosReply []common.RpcReplyGetaddressutxos
 	err = json.Unmarshal(result, &utxosReply)
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument,
@@ -1001,7 +1001,7 @@ func (s *lwdStreamer) GetSubtreeRoots(arg *walletrpc.GetSubtreeRootsArg, resp wa
 		return status.Errorf(codes.InvalidArgument,
 			"GetSubtreeRoots: z_getsubtreesbyindex, error: %s", rpcErr.Error())
 	}
-	var reply common.ZcashdRpcReplyGetsubtreebyindex
+	var reply common.RpcReplyGetsubtreebyindex
 	err = json.Unmarshal(result, &reply)
 	if err != nil {
 		return status.Errorf(codes.Unknown,
@@ -1104,7 +1104,7 @@ func (s *DarksideStreamer) Stop(ctx context.Context, _ *walletrpc.Empty) (*walle
 }
 
 // StageBlocksStream accepts a list of blocks from the wallet test code,
-// and makes them available to present from the mock zcashd's GetBlock rpc.
+// and makes them available to present from the mock node's GetBlock rpc.
 func (s *DarksideStreamer) StageBlocksStream(blocks walletrpc.DarksideStreamer_StageBlocksStreamServer) error {
 	for {
 		b, err := blocks.Recv()
@@ -1194,7 +1194,7 @@ func (s *DarksideStreamer) ClearIncomingTransactions(ctx context.Context, e *wal
 
 // AddAddressUtxo adds a UTXO which will be returned by GetAddressUtxos() (above)
 func (s *DarksideStreamer) AddAddressUtxo(ctx context.Context, arg *walletrpc.GetAddressUtxosReply) (*walletrpc.Empty, error) {
-	utxosReply := common.ZcashdRpcReplyGetaddressutxos{
+	utxosReply := common.RpcReplyGetaddressutxos{
 		Address:     arg.Address,
 		Txid:        hash32.Encode(hash32.Reverse(hash32.FromSlice(arg.Txid))),
 		OutputIndex: int64(arg.Index),

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
-	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/ini.v1 v1.67.0
@@ -49,6 +48,7 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
+	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect

--- a/lightwallet-protocol/walletrpc/service.proto
+++ b/lightwallet-protocol/walletrpc/service.proto
@@ -63,11 +63,11 @@ message RawTransaction {
     // The height at which the transaction is mined, or a sentinel value.
     //
     // Due to an error in the original protobuf definition, it is necessary to
-    // reinterpret the result of the `getrawtransaction` RPC call. Zcashd will
+    // reinterpret the result of the `getrawtransaction` RPC call. The node will
     // return the int64 value `-1` for the height of transactions that appear
     // in the block index, but which are not mined in the main chain. Here, the
     // height field of `RawTransaction` was erroneously created as a `uint64`,
-    // and as such we must map the response from the zcashd RPC API to be
+    // and as such we must map the response from the node's RPC API to be
     // representable within this space. Additionally, the `height` field will
     // be absent for transactions in the mempool, resulting in the default
     // value of `0` being set. Therefore, the meanings of the `height` field of
@@ -109,9 +109,9 @@ message LightdInfo {
     string branch = 9;
     string buildDate = 10;
     string buildUser = 11;
-    uint64 estimatedHeight = 12;        // less than tip height if zcashd is syncing
-    string zcashdBuild = 13;            // example: "v4.1.1-877212414"
-    string zcashdSubversion = 14;       // example: "/MagicBean:4.1.1/"
+    uint64 estimatedHeight = 12;        // less than tip height if the node is syncing
+    string zcashdBuild = 13;            // the backend node build string, e.g. "2.5.0"
+    string zcashdSubversion = 14;       // example: "/Zebra:2.5.0/"
     string donationAddress = 15;        // Zcash donation UA address
     string upgradeName = 16;            // name of next pending network upgrade, empty if none scheduled
     uint64 upgradeHeight = 17;          // height of next pending upgrade, zero if none is scheduled
@@ -272,7 +272,7 @@ service CompactTxStreamer {
       option deprecated = true;
     }
 
-    // Return the requested full (not compact) transaction (as from zcashd)
+    // Return the requested full (not compact) transaction (as from the node)
     rpc GetTransaction(TxFilter) returns (RawTransaction) {}
 
     // Submit the given transaction to the Zcash network

--- a/parser/block.go
+++ b/parser/block.go
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-// Package parser deserializes blocks from zcashd.
+// Package parser deserializes blocks from the Zcash node.
 package parser
 
 import (

--- a/parser/block_header.go
+++ b/parser/block_header.go
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-// Package parser deserializes the block header from zcashd.
+// Package parser deserializes the block header from the Zcash node.
 package parser
 
 import (

--- a/parser/internal/bytestring/bytestring.go
+++ b/parser/internal/bytestring/bytestring.go
@@ -236,10 +236,10 @@ func (s *String) ReadUint64(out *uint64) bool {
 // ReadScriptInt64 reads and interprets a Bitcoin-custom compact integer
 // encoding used for int64 numbers in scripts.
 //
-// Serializer in zcashd:
+// Reference serializer (zcash/zcash):
 // https://github.com/zcash/zcash/blob/4df60f4b334dd9aee5df3a481aee63f40b52654b/src/script/script.h#L363-L378
 //
-// Partial parser in zcashd:
+// Reference partial parser (zcash/zcash):
 // https://github.com/zcash/zcash/blob/4df60f4b334dd9aee5df3a481aee63f40b52654b/src/script/interpreter.cpp#L308-L335
 func (s *String) ReadScriptInt64(num *int64) bool {
 	// First byte is either an integer opcode, or the number of bytes in the

--- a/parser/transaction.go
+++ b/parser/transaction.go
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-// Package parser deserializes (full) transactions (zcashd).
+// Package parser deserializes (full) transactions.
 package parser
 
 import (
@@ -365,7 +365,7 @@ func (p *action) ToCompact() *walletrpc.CompactOrchardAction {
 	}
 }
 
-// Transaction encodes a full (zcashd) transaction.
+// Transaction encodes a full Zcash transaction.
 type Transaction struct {
 	*rawTransaction
 	rawBytes []byte

--- a/parser/transaction_test.go
+++ b/parser/transaction_test.go
@@ -87,7 +87,7 @@ func TestV5TransactionParser(t *testing.T) {
 			t.Fatalf("Test did not consume entire buffer, %d remaining", len(rest))
 		}
 		// Currently, we can't check the txid because we get that from
-		// zcashd (getblock rpc) rather than computing it ourselves.
+		// the node (getblock rpc) rather than computing it ourselves.
 		// https://github.com/zcash/lightwalletd/issues/392
 		if tx.version != uint32(txtestdata.Version) {
 			t.Fatal("version miscompare")

--- a/smoke-test.bash
+++ b/smoke-test.bash
@@ -113,7 +113,7 @@ function compare {
 if $start_server
 then
   echo starting the server, this takes a few seconds ...
-  go run main.go --donation-address udonationaddr --zcash-conf-path ~/.zcash/zcash.conf --no-tls-very-insecure --darkside-timeout 999999 --darkside-very-insecure &
+  go run main.go --donation-address udonationaddr --no-tls-very-insecure --darkside-timeout 999999 --darkside-very-insecure &
   sleep 8
 fi
 
@@ -130,7 +130,7 @@ gt StageTransactions '{"height":663190,"url":"https://raw.githubusercontent.com/
 echo -n test: ApplyStaged to block 663210 ...
 gt ApplyStaged '{"height":663210}'
 
-# the block ingestor needs time to receive the block from the (fake) zcashd
+# the block ingestor needs time to receive the block from the (fake) node
 wait_height 663190
 
 # The transaction in this block is on mainnet, but in block 663229.

--- a/testtools/genblocks/main.go
+++ b/testtools/genblocks/main.go
@@ -4,7 +4,7 @@
 //
 // This tool reads a set of files, each containing a list of transactions
 // (one per line, can be empty), and writes to stdout a list of blocks,
-// one per input file, in hex format (same as zcash-cli getblock 12345 0),
+// one per input file, in hex format (same as the getblock RPC with verbose=0),
 // each on a separate line. Each fake block contains a fake coinbase
 // transaction and all of the transactions in the corresponding file.
 

--- a/utils/pullblocks.sh
+++ b/utils/pullblocks.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
+# Fetches raw (hex-encoded) blocks from a Zcash node using JSON-RPC,
+# one block per line, for use with submitblocks.sh (darksidewalletd).
 # Usage: ./pullblocks.sh 500000 500100 > blocks.txt
+# Set RPCHOST and RPCPORT to override the default node RPC endpoint.
 test $# -ne 2 && { echo usage: $0 start end;exit 1;}
+
+RPCHOST=${RPCHOST:-127.0.0.1}
+RPCPORT=${RPCPORT:-8232}
 
 let i=$1
 while test $i -le $2
 do
-    zcash-cli getblock $i 0
+    curl -s -X POST -H 'Content-Type: application/json' \
+        --data '{"jsonrpc":"2.0","id":"pullblocks","method":"getblock","params":["'$i'",0]}' \
+        "http://$RPCHOST:$RPCPORT/" | jq -r .result
     let i++
 done

--- a/walletrpc/darkside.proto
+++ b/walletrpc/darkside.proto
@@ -60,7 +60,7 @@ message DarksideAddressTransaction {
 
 // Darksidewalletd maintains two staging areas, blocks and transactions. The
 // Stage*() gRPCs add items to the staging area; ApplyStaged() "applies" everything
-// in the staging area to the working (operational) state that the mock zcashd
+// in the staging area to the working (operational) state that the mock Zcash node
 // serves; transactions are placed into their corresponding blocks (by height).
 service DarksideStreamer {
     // Reset reverts all darksidewalletd state (active block range, latest height,
@@ -74,7 +74,7 @@ service DarksideStreamer {
 
     // StageBlocksStream accepts a list of blocks and saves them into the blocks
     // staging area until ApplyStaged() is called; there is no immediate effect on
-    // the mock zcashd. Blocks are hex-encoded. Order is important, see ApplyStaged.
+    // the mock Zcash node. Blocks are hex-encoded. Order is important, see ApplyStaged.
     rpc StageBlocksStream(stream DarksideBlock) returns (Empty) {}
 
     // StageBlocks is the same as StageBlocksStream() except the blocks are fetched
@@ -92,7 +92,7 @@ service DarksideStreamer {
     // staging area until ApplyStaged() is called. Note that these transactions
     // are not returned by the production GetTransaction() gRPC until they
     // appear in a "mined" block (contained in the active blockchain presented
-    // by the mock zcashd).
+    // by the mock Zcash node).
     rpc StageTransactionsStream(stream RawTransaction) returns (Empty) {}
 
     // StageTransactions is the same except the transactions are fetched from
@@ -102,7 +102,7 @@ service DarksideStreamer {
 
     // ApplyStaged iterates the list of blocks that were staged by the
     // StageBlocks*() gRPCs, in the order they were staged, and "merges" each
-    // into the active, working blocks list that the mock zcashd is presenting
+    // into the active, working blocks list that the mock Zcash node is presenting
     // to lightwalletd. Even as each block is applied, the active list can't
     // have gaps; if the active block range is 1000-1006, and the staged block
     // range is 1003-1004, the resulting range is 1000-1004, with 1000-1002
@@ -112,10 +112,10 @@ service DarksideStreamer {
     // the order received) into each one's corresponding (by height) block
     // The staging area is then cleared.
     //
-    // The argument specifies the latest block height that mock zcashd reports
+    // The argument specifies the latest block height that mock Zcash node reports
     // (i.e. what's returned by GetLatestBlock). Note that ApplyStaged() can
     // also be used to simply advance the latest block height presented by mock
-    // zcashd. That is, there doesn't need to be anything in the staging area.
+    // node. That is, there doesn't need to be anything in the staging area.
     rpc ApplyStaged(DarksideHeight) returns (Empty) {}
 
     // Calls to the production gRPC SendTransaction() store the transaction in

--- a/walletrpc/darkside_grpc.pb.go
+++ b/walletrpc/darkside_grpc.pb.go
@@ -49,7 +49,7 @@ const (
 //
 // Darksidewalletd maintains two staging areas, blocks and transactions. The
 // Stage*() gRPCs add items to the staging area; ApplyStaged() "applies" everything
-// in the staging area to the working (operational) state that the mock zcashd
+// in the staging area to the working (operational) state that the mock Zcash node
 // serves; transactions are placed into their corresponding blocks (by height).
 type DarksideStreamerClient interface {
 	// Reset reverts all darksidewalletd state (active block range, latest height,
@@ -62,7 +62,7 @@ type DarksideStreamerClient interface {
 	Reset(ctx context.Context, in *DarksideMetaState, opts ...grpc.CallOption) (*Empty, error)
 	// StageBlocksStream accepts a list of blocks and saves them into the blocks
 	// staging area until ApplyStaged() is called; there is no immediate effect on
-	// the mock zcashd. Blocks are hex-encoded. Order is important, see ApplyStaged.
+	// the mock Zcash node. Blocks are hex-encoded. Order is important, see ApplyStaged.
 	StageBlocksStream(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[DarksideBlock, Empty], error)
 	// StageBlocks is the same as StageBlocksStream() except the blocks are fetched
 	// from the given URL. Blocks are one per line, hex-encoded (not JSON).
@@ -77,7 +77,7 @@ type DarksideStreamerClient interface {
 	// staging area until ApplyStaged() is called. Note that these transactions
 	// are not returned by the production GetTransaction() gRPC until they
 	// appear in a "mined" block (contained in the active blockchain presented
-	// by the mock zcashd).
+	// by the mock Zcash node).
 	StageTransactionsStream(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[RawTransaction, Empty], error)
 	// StageTransactions is the same except the transactions are fetched from
 	// the given url. They are all staged into the block at the given height.
@@ -85,7 +85,7 @@ type DarksideStreamerClient interface {
 	StageTransactions(ctx context.Context, in *DarksideTransactionsURL, opts ...grpc.CallOption) (*Empty, error)
 	// ApplyStaged iterates the list of blocks that were staged by the
 	// StageBlocks*() gRPCs, in the order they were staged, and "merges" each
-	// into the active, working blocks list that the mock zcashd is presenting
+	// into the active, working blocks list that the mock Zcash node is presenting
 	// to lightwalletd. Even as each block is applied, the active list can't
 	// have gaps; if the active block range is 1000-1006, and the staged block
 	// range is 1003-1004, the resulting range is 1000-1004, with 1000-1002
@@ -95,10 +95,10 @@ type DarksideStreamerClient interface {
 	// the order received) into each one's corresponding (by height) block
 	// The staging area is then cleared.
 	//
-	// The argument specifies the latest block height that mock zcashd reports
+	// The argument specifies the latest block height that mock Zcash node reports
 	// (i.e. what's returned by GetLatestBlock). Note that ApplyStaged() can
 	// also be used to simply advance the latest block height presented by mock
-	// zcashd. That is, there doesn't need to be anything in the staging area.
+	// node. That is, there doesn't need to be anything in the staging area.
 	ApplyStaged(ctx context.Context, in *DarksideHeight, opts ...grpc.CallOption) (*Empty, error)
 	// Calls to the production gRPC SendTransaction() store the transaction in
 	// a separate area (not the staging area); this method returns all transactions
@@ -341,7 +341,7 @@ func (c *darksideStreamerClient) Stop(ctx context.Context, in *Empty, opts ...gr
 //
 // Darksidewalletd maintains two staging areas, blocks and transactions. The
 // Stage*() gRPCs add items to the staging area; ApplyStaged() "applies" everything
-// in the staging area to the working (operational) state that the mock zcashd
+// in the staging area to the working (operational) state that the mock Zcash node
 // serves; transactions are placed into their corresponding blocks (by height).
 type DarksideStreamerServer interface {
 	// Reset reverts all darksidewalletd state (active block range, latest height,
@@ -354,7 +354,7 @@ type DarksideStreamerServer interface {
 	Reset(context.Context, *DarksideMetaState) (*Empty, error)
 	// StageBlocksStream accepts a list of blocks and saves them into the blocks
 	// staging area until ApplyStaged() is called; there is no immediate effect on
-	// the mock zcashd. Blocks are hex-encoded. Order is important, see ApplyStaged.
+	// the mock Zcash node. Blocks are hex-encoded. Order is important, see ApplyStaged.
 	StageBlocksStream(grpc.ClientStreamingServer[DarksideBlock, Empty]) error
 	// StageBlocks is the same as StageBlocksStream() except the blocks are fetched
 	// from the given URL. Blocks are one per line, hex-encoded (not JSON).
@@ -369,7 +369,7 @@ type DarksideStreamerServer interface {
 	// staging area until ApplyStaged() is called. Note that these transactions
 	// are not returned by the production GetTransaction() gRPC until they
 	// appear in a "mined" block (contained in the active blockchain presented
-	// by the mock zcashd).
+	// by the mock Zcash node).
 	StageTransactionsStream(grpc.ClientStreamingServer[RawTransaction, Empty]) error
 	// StageTransactions is the same except the transactions are fetched from
 	// the given url. They are all staged into the block at the given height.
@@ -377,7 +377,7 @@ type DarksideStreamerServer interface {
 	StageTransactions(context.Context, *DarksideTransactionsURL) (*Empty, error)
 	// ApplyStaged iterates the list of blocks that were staged by the
 	// StageBlocks*() gRPCs, in the order they were staged, and "merges" each
-	// into the active, working blocks list that the mock zcashd is presenting
+	// into the active, working blocks list that the mock Zcash node is presenting
 	// to lightwalletd. Even as each block is applied, the active list can't
 	// have gaps; if the active block range is 1000-1006, and the staged block
 	// range is 1003-1004, the resulting range is 1000-1004, with 1000-1002
@@ -387,10 +387,10 @@ type DarksideStreamerServer interface {
 	// the order received) into each one's corresponding (by height) block
 	// The staging area is then cleared.
 	//
-	// The argument specifies the latest block height that mock zcashd reports
+	// The argument specifies the latest block height that mock Zcash node reports
 	// (i.e. what's returned by GetLatestBlock). Note that ApplyStaged() can
 	// also be used to simply advance the latest block height presented by mock
-	// zcashd. That is, there doesn't need to be anything in the staging area.
+	// node. That is, there doesn't need to be anything in the staging area.
 	ApplyStaged(context.Context, *DarksideHeight) (*Empty, error)
 	// Calls to the production gRPC SendTransaction() store the transaction in
 	// a separate area (not the staging area); this method returns all transactions

--- a/walletrpc/service.pb.go
+++ b/walletrpc/service.pb.go
@@ -332,11 +332,11 @@ type RawTransaction struct {
 	// The height at which the transaction is mined, or a sentinel value.
 	//
 	// Due to an error in the original protobuf definition, it is necessary to
-	// reinterpret the result of the `getrawtransaction` RPC call. Zcashd will
+	// reinterpret the result of the `getrawtransaction` RPC call. The node will
 	// return the int64 value `-1` for the height of transactions that appear
 	// in the block index, but which are not mined in the main chain. Here, the
 	// height field of `RawTransaction` was erroneously created as a `uint64`,
-	// and as such we must map the response from the zcashd RPC API to be
+	// and as such we must map the response from the node's RPC API to be
 	// representable within this space. Additionally, the `height` field will
 	// be absent for transactions in the mempool, resulting in the default
 	// value of `0` being set. Therefore, the meanings of the `height` field of
@@ -540,9 +540,9 @@ type LightdInfo struct {
 	Branch                     string                 `protobuf:"bytes,9,opt,name=branch,proto3" json:"branch,omitempty"`
 	BuildDate                  string                 `protobuf:"bytes,10,opt,name=buildDate,proto3" json:"buildDate,omitempty"`
 	BuildUser                  string                 `protobuf:"bytes,11,opt,name=buildUser,proto3" json:"buildUser,omitempty"`
-	EstimatedHeight            uint64                 `protobuf:"varint,12,opt,name=estimatedHeight,proto3" json:"estimatedHeight,omitempty"`                      // less than tip height if zcashd is syncing
-	ZcashdBuild                string                 `protobuf:"bytes,13,opt,name=zcashdBuild,proto3" json:"zcashdBuild,omitempty"`                               // example: "v4.1.1-877212414"
-	ZcashdSubversion           string                 `protobuf:"bytes,14,opt,name=zcashdSubversion,proto3" json:"zcashdSubversion,omitempty"`                     // example: "/MagicBean:4.1.1/"
+	EstimatedHeight            uint64                 `protobuf:"varint,12,opt,name=estimatedHeight,proto3" json:"estimatedHeight,omitempty"`                      // less than tip height if the node is syncing
+	ZcashdBuild                string                 `protobuf:"bytes,13,opt,name=zcashdBuild,proto3" json:"zcashdBuild,omitempty"`                               // the backend node build string, e.g. "2.5.0"
+	ZcashdSubversion           string                 `protobuf:"bytes,14,opt,name=zcashdSubversion,proto3" json:"zcashdSubversion,omitempty"`                     // example: "/Zebra:2.5.0/"
 	DonationAddress            string                 `protobuf:"bytes,15,opt,name=donationAddress,proto3" json:"donationAddress,omitempty"`                       // Zcash donation UA address
 	UpgradeName                string                 `protobuf:"bytes,16,opt,name=upgradeName,proto3" json:"upgradeName,omitempty"`                               // name of next pending network upgrade, empty if none scheduled
 	UpgradeHeight              uint64                 `protobuf:"varint,17,opt,name=upgradeHeight,proto3" json:"upgradeHeight,omitempty"`                          // height of next pending upgrade, zero if none is scheduled

--- a/walletrpc/service_grpc.pb.go
+++ b/walletrpc/service_grpc.pb.go
@@ -92,7 +92,7 @@ type CompactTxStreamerClient interface {
 	// Note: this method is deprecated; use `GetBlockRange` with the
 	// appropriate `poolTypes` instead.
 	GetBlockRangeNullifiers(ctx context.Context, in *BlockRange, opts ...grpc.CallOption) (grpc.ServerStreamingClient[CompactBlock], error)
-	// Return the requested full (not compact) transaction (as from zcashd)
+	// Return the requested full (not compact) transaction (as from the node)
 	GetTransaction(ctx context.Context, in *TxFilter, opts ...grpc.CallOption) (*RawTransaction, error)
 	// Submit the given transaction to the Zcash network
 	SendTransaction(ctx context.Context, in *RawTransaction, opts ...grpc.CallOption) (*SendResponse, error)
@@ -471,7 +471,7 @@ type CompactTxStreamerServer interface {
 	// Note: this method is deprecated; use `GetBlockRange` with the
 	// appropriate `poolTypes` instead.
 	GetBlockRangeNullifiers(*BlockRange, grpc.ServerStreamingServer[CompactBlock]) error
-	// Return the requested full (not compact) transaction (as from zcashd)
+	// Return the requested full (not compact) transaction (as from the node)
 	GetTransaction(context.Context, *TxFilter) (*RawTransaction, error)
 	// Submit the given transaction to the Zcash network
 	SendTransaction(context.Context, *RawTransaction) (*SendResponse, error)


### PR DESCRIPTION
zcashd is fully deprecated and no longer runs on mainnet or testnet, so no lightwalletd can point at one. Remove zcashd-specific support while keeping all operator-facing interfaces unchanged, and use node-neutral wording since there are multiple Zcash node implementations (zebra, zakura):

- Remove the startup backend-detection logic and the zcashd-only getexperimentalfeatures check; lightwalletd now works with any Zcash full node that provides the expected JSON-RPC interface. Also remove the now-constant NodeName global.
- Rename the internal Zcashd*-prefixed RPC wire types (used for all backends) to backend-neutral Rpc* names, and getTaddressBalanceZcashdRpc to getTaddressBalanceRpc.
- Reword zcashd references in comments, logs, docs, and protos to refer generically to the "Zcash node", regenerating walletrpc/*.pb.go and docs/rtd/index.html (comment-only changes; wire format untouched).
- Remove the stale zcashd-specific Makefile docker targets and rewrite utils/pullblocks.sh to use JSON-RPC directly instead of zcash-cli.

No operator-facing interfaces changed: the --zcash-conf-path option, the supported config file formats (zcash.conf-style INI and zebrad-style TOML), environment variables, and the docker-compose files are all unchanged; updating the docker-compose stack is planned as a follow-up (referencing zecrocks/zcash-stack). The LightdInfo gRPC fields zcashdBuild and zcashdSubversion keep their names for wire compatibility and report the connected node's build and subversion strings.

Followup work:
- Update docker compose stack in this repo
- Consider changing any ENV variable names that contain "ZCASHD"