### PR TITLE
Run as a non-root user in containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The most recent changes are listed first.
 
+## [Unreleased]
+
+### Changed
+
+- Build the Docker image in two stages on Alpine, shipping only the compiled
+  binary and its runtime dependencies instead of the full Go toolchain and
+  source tree. This takes the image from about 1.9 GB to about 50 MB, and
+  dependency downloads are cached in their own layer so they are not repeated
+  on every source change. The container still runs as root and the
+  `lightwalletd` user still has uid/gid 2002, so no migration is required.
+  Note that the image is now Alpine-based and so has no `bash`; use `sh` for
+  interactive shells into the container.
+
 ## [0.5.1] - 2026-07-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ The most recent changes are listed first.
 
 ### Changed
 
+- **Breaking (Docker):** the container now runs as the unprivileged
+  `lightwalletd` user (uid/gid 2002) instead of as root. The uid and gid are
+  unchanged — previous images created this user but never switched to it.
+
+  Operators upgrading an existing deployment must make the data directory
+  writable by that user, because it was created by a root-running container:
+
+  ```
+  chown -R 2002:2002 /path/to/lightwalletd/data
+  ```
+
+  Without this, lightwalletd fails with "permission denied" on its block
+  cache. Deployments using a fresh volume need no action, as a new volume
+  inherits the image's 2002:2002 ownership. Operators who need the old
+  behaviour can run the container with `--user 0:0`.
+
 - Build the Docker image in two stages on Alpine, shipping only the compiled
   binary and its runtime dependencies instead of the full Go toolchain and
   source tree. This takes the image from about 1.9 GB to about 50 MB, and

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,10 @@ RUN apk add --no-cache ca-certificates \
 
 COPY --from=builder /go/src/github.com/zcash/lightwalletd/lightwalletd /usr/local/bin/
 
-# NB: the container still runs as root, matching the previous image. The
-# lightwalletd user exists and owns the db directory, but switching to it
-# would break existing deployments whose data directories were written as
-# root, so that change is deliberately left separate.
+# Run unprivileged. Existing deployments whose data directory was written by
+# an earlier root-running image must chown it to 2002:2002 (or run the
+# container with --user 0:0) before upgrading; see CHANGELOG.md.
+USER lightwalletd
 WORKDIR /srv/lightwalletd
 
 ENTRYPOINT ["lightwalletd"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,31 @@
-FROM golang:1.25 AS lightwalletd_base
+FROM golang:1.25-alpine AS builder
 
-ADD . /go/src/github.com/zcash/lightwalletd
+RUN apk add --no-cache make git
+
 WORKDIR /go/src/github.com/zcash/lightwalletd
 
-RUN make \
-  && /usr/bin/install -c ./lightwalletd /usr/local/bin/ \
-  && mkdir -p /var/lib/lightwalletd/db \
-  && chown 2002:2002 /var/lib/lightwalletd/db
+# Cache dependencies
+COPY go.mod go.sum ./
+RUN go mod download
 
-ARG LWD_USER=lightwalletd
-ARG LWD_UID=2002
+COPY . .
 
-RUN useradd --home-dir "/srv/$LWD_USER" \
-            --shell /bin/bash \
-            --create-home \
-            --uid "$LWD_UID" \
-            "$LWD_USER"
+RUN make build
 
-WORKDIR "/srv/$LWD_USER"
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates \
+    && adduser -D -h /srv/lightwalletd -u 2002 lightwalletd \
+    && mkdir -p /var/lib/lightwalletd/db \
+    && chown lightwalletd:lightwalletd /var/lib/lightwalletd/db
+
+COPY --from=builder /go/src/github.com/zcash/lightwalletd/lightwalletd /usr/local/bin/
+
+# NB: the container still runs as root, matching the previous image. The
+# lightwalletd user exists and owns the db directory, but switching to it
+# would break existing deployments whose data directories were written as
+# root, so that change is deliberately left separate.
+WORKDIR /srv/lightwalletd
 
 ENTRYPOINT ["lightwalletd"]
 CMD ["--help"]


### PR DESCRIPTION
The lightwalletd Dockerfile adds a user account that it does not use, instead running lightwalletd as root.

Prerequisite: Alpine PR #578

This PR runs lightwalletd as a non-root user inside containers for additional security.

This will be a breaking change for container operators due to permissions variances on the data directory across container runtimes, and as such should cause a minor version bump of lightwalletd if merged in my opinion.