### PR TITLE
CHANGELOG: drop the GHSA reference from the parser bounds entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,9 @@ The most recent changes are listed first.
   spends and outputs, Orchard actions, JoinSplits, and the block's
   transaction count) than the input could possibly contain; sizing a slice
   from such a count previously allocated gigabytes before the first element
-  failed to parse, exhausting memory (GHSA-ph5v-77v6-j498).
+  failed to parse. The parser only consumes data supplied by the configured
+  backend node (or by the opt-in darkside testing facility), so this is
+  defensive hardening rather than a remotely reachable defect (#562).
 
 - Make `common.RawRequest` context-aware so cancelled `GetBlockRange` /
   `GetBlockRangeNullifiers` streams abort in-flight zcashd JSON-RPC calls


### PR DESCRIPTION
Follow-up to the disposition of **GHSA-ph5v-77v6-j498**, which is being closed as *Not a Vulnerability*.

The v0.5.0 CHANGELOG entry for the parser element-count bounds cites that advisory by ID. Since it won't be published, the reference would dangle permanently for anyone who tried to look it up.

## What changed

One entry, in the `[0.5.0]` section:

- **Drops** `(GHSA-ph5v-77v6-j498)`, **cites #562** instead — the PR that actually landed the bounds.
- **Corrects the characterisation.** The old text ended "…exhausting memory", which reads as a remotely reachable DoS. The parser only ever consumes bytes supplied by the configured backend node, or by the opt-in `--darkside-very-insecure` facility. Reaching it requires a compromised backend, a MITM on the lightwalletd↔backend channel, or a deliberate operator exposure — each of which already grants strictly worse capabilities. So it's defensive hardening, not a remotely reachable defect, and the entry now says so.

No code change; the bounds themselves are unchanged and remain in place.

## Note on amending a released section

This edits the `[0.5.0]` block after v0.5.0 shipped. That's deliberate — the reference is simply wrong, and leaving it would mislead anyone reading the changelog on master. The `v0.5.0` and `v0.5.1` tags keep the original wording, so the release artifacts are untouched; this only corrects the file going forward.