### PR TITLE
Narrow the GetMempoolTx mutex to the cache it protects (GHSA-f9pw-q493-7qvh, GHSA-9p9r-mggr-8q9g)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The most recent changes are listed first.
 
-## [Unreleased]
+## [0.5.2] - 2026-07-30
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The most recent changes are listed first.
 
+## [Unreleased]
+
+### Fixed
+
+- Narrow the `GetMempoolTx` mutex to the cache snapshot it protects, instead
+  of holding it across the whole handler (GHSA-f9pw-q493-7qvh,
+  GHSA-9p9r-mggr-8q9g). The mempool refresh issues one `getrawmempool` plus a
+  `getrawtransaction` per new txid, and the response loop streams to the
+  client; both ran inside the critical section, so a single caller's backend
+  round-trips — or one client that simply stopped reading its stream — stalled
+  every other `GetMempoolTx` caller. The backend calls and the streaming sends
+  now run outside the lock, which is taken only to claim a refresh, snapshot
+  the cache, and publish the new one.
+
+- A `GetMempoolTx` refresh now stops when the client that triggered it
+  disconnects, instead of running to completion. Since the backend calls
+  observe the request context, every remaining fetch would otherwise fail and
+  be treated as a transaction that had left the mempool, publishing a cache
+  missing nearly all of its entries and degrading it for other callers until
+  the next refresh.
+
+- A `GetMempoolTx` refresh that fails part-way no longer leaves the cached
+  txid list updated while the transaction map still holds the previous
+  contents; the two are now published together.
+
 ## [0.5.1] - 2026-07-27
 
 ### Added

--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -1021,3 +1021,141 @@ func TestGetMempoolTxExcludeListCap(t *testing.T) {
 		t.Fatal("a request at the cap should have reached the backend")
 	}
 }
+
+// testmempoolslow is a GetMempoolTx stream whose Send blocks until released,
+// standing in for a client that has stopped reading its stream.
+type testmempoolslow struct {
+	walletrpc.CompactTxStreamer_GetMempoolTxServer
+	sending chan struct{}
+	release chan struct{}
+	once    bool
+}
+
+func (t *testmempoolslow) Context() context.Context { return context.Background() }
+
+func (t *testmempoolslow) Send(tx *walletrpc.CompactTx) error {
+	if !t.once {
+		t.once = true
+		close(t.sending)
+		<-t.release
+	}
+	return nil
+}
+
+// A client that stops reading its stream must not stall other GetMempoolTx
+// callers. resp.Send blocks on the client's flow control, so holding s.mutex
+// across it serialized every caller behind the slowest one
+// (GHSA-9p9r-mggr-8q9g). The same applies to the refresh RPCs
+// (GHSA-f9pw-q493-7qvh) -- neither may run inside the critical section.
+func TestGetMempoolTxSlowClientDoesNotBlockOthers(t *testing.T) {
+	testT = t
+	defer resetGlobals()
+	lwd, _ := testsetup()
+
+	// Seed a fresh cache holding one Orchard tx, so neither caller triggers a
+	// refresh and both reach the send loop.
+	txid := strings.Repeat("ab", 32)
+	tx := &walletrpc.CompactTx{
+		Actions: []*walletrpc.CompactOrchardAction{{Nullifier: make([]byte, 32)}},
+	}
+	m := map[string]*walletrpc.CompactTx{txid: tx}
+	mempoolList = []string{txid}
+	mempoolMap = &m
+	lastMempool = time.Now()
+
+	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
+		testT.Fatal("no mempool refresh expected; the cache was seeded fresh")
+		return nil, nil
+	}
+
+	req := &walletrpc.GetMempoolTxRequest{}
+
+	// Caller A parks inside Send, as a stalled client would.
+	slow := &testmempoolslow{sending: make(chan struct{}), release: make(chan struct{})}
+	slowDone := make(chan error, 1)
+	go func() { slowDone <- lwd.GetMempoolTx(req, slow) }()
+	select {
+	case <-slow.sending:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the slow caller never reached Send")
+	}
+
+	// Caller B must finish while A is still parked. If the mutex were still
+	// held across Send, this would block until the test timed out.
+	fastDone := make(chan error, 1)
+	go func() { fastDone <- lwd.GetMempoolTx(req, &testmempooltx{}) }()
+	select {
+	case err := <-fastDone:
+		if err != nil {
+			t.Fatal("second caller failed:", err)
+		}
+	case <-time.After(10 * time.Second):
+		close(slow.release)
+		t.Fatal("second caller blocked behind the stalled client -- the mutex is still held across resp.Send")
+	}
+
+	close(slow.release)
+	if err := <-slowDone; err != nil {
+		t.Fatal("slow caller failed:", err)
+	}
+}
+
+// testmempoolcancel is a GetMempoolTx stream whose context is cancelled after
+// the refresh has started, standing in for a client that hangs up mid-refresh.
+type testmempoolcancel struct {
+	walletrpc.CompactTxStreamer_GetMempoolTxServer
+	ctx context.Context
+}
+
+func (t *testmempoolcancel) Context() context.Context        { return t.ctx }
+func (t *testmempoolcancel) Send(*walletrpc.CompactTx) error { return nil }
+
+// If the client that triggered a refresh disconnects, the refresh must abort
+// rather than run to completion. RawRequest observes the context, so every
+// remaining per-txid fetch would fail and be swallowed by the "mempool
+// transactions can disappear" path, publishing a cache missing nearly every
+// transaction and degrading it for other callers (GHSA-f9pw-q493-7qvh).
+func TestGetMempoolTxAbortsRefreshOnClientCancel(t *testing.T) {
+	testT = t
+	defer resetGlobals()
+	lwd, _ := testsetup()
+
+	// A mempool of 50 txids, none of them already cached, so the refresh has
+	// plenty of per-txid fetches left to do after the cancel.
+	var txids []string
+	for i := 0; i < 50; i++ {
+		txids = append(txids, fmt.Sprintf("%064x", i))
+	}
+	listJSON, _ := json.Marshal(txids)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	fetches := 0
+	common.RawRequest = func(_ context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
+		switch method {
+		case "getrawmempool":
+			return listJSON, nil
+		case "getrawtransaction":
+			fetches++
+			cancel() // the client hangs up after the first fetch
+			return nil, errors.New("context canceled")
+		}
+		testT.Fatal("unexpected method", method)
+		return nil, nil
+	}
+
+	err := lwd.GetMempoolTx(&walletrpc.GetMempoolTxRequest{}, &testmempoolcancel{ctx: ctx})
+	if err == nil {
+		t.Fatal("expected a context error once the client cancelled")
+	}
+	if status.Code(err) != codes.Canceled {
+		t.Fatal("expected Canceled, got:", status.Code(err), err)
+	}
+	// The refresh must have stopped early rather than grinding through all 50.
+	if fetches > 2 {
+		t.Fatalf("refresh kept fetching after cancel: %d fetches for 50 txids", fetches)
+	}
+	// And it must not have published a degraded cache.
+	if mempoolMap != nil && len(*mempoolMap) > 0 {
+		t.Fatalf("a partial cache was published: %d entries", len(*mempoolMap))
+	}
+}

--- a/frontend/service.go
+++ b/frontend/service.go
@@ -737,29 +737,41 @@ func (s *lwdStreamer) GetMempoolTx(exclude *walletrpc.GetMempoolTxRequest, resp 
 		excludeHex[i] = hex.EncodeToString(rev)
 	}
 
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
+	// Hold the mutex only long enough to decide whether this call refreshes
+	// the cache, and to snapshot it and update lastMempool to prevent another
+	// thread from refreshing while our thread is doing that.
 	streamCtx := resp.Context()
-	if time.Since(lastMempool).Seconds() >= 2 {
+	s.mutex.Lock()
+	refresh := time.Since(lastMempool).Seconds() >= 2
+	if refresh {
 		lastMempool = time.Now()
+	}
+	cachedList := mempoolList
+	var cachedMap map[string]*walletrpc.CompactTx
+	if mempoolMap != nil {
+		cachedMap = *mempoolMap
+	}
+	s.mutex.Unlock()
+
+	if refresh {
 		// Refresh our copy of the mempool.
 		params := make([]json.RawMessage, 0)
 		result, rpcErr := common.RawRequest(streamCtx, "getrawmempool", params)
 		if rpcErr != nil {
 			return status.Errorf(codes.Internal, "GetMempoolTx: getrawmempool error: %s", rpcErr.Error())
 		}
-		err := json.Unmarshal(result, &mempoolList)
+		var newmempoolList []string
+		err := json.Unmarshal(result, &newmempoolList)
 		if err != nil {
 			return status.Errorf(codes.Unknown,
 				"GetMempoolTx: failed to unmarshal getrawmempool reply, error: %s", err.Error())
 		}
 		newmempoolMap := make(map[string]*walletrpc.CompactTx)
-		if mempoolMap == nil {
-			mempoolMap = &newmempoolMap
-		}
-		for _, txidstr := range mempoolList {
-			if ctx, ok := (*mempoolMap)[txidstr]; ok {
+		for _, txidstr := range newmempoolList {
+			if err := streamCtx.Err(); err != nil {
+				return status.FromContextError(err).Err()
+			}
+			if ctx, ok := cachedMap[txidstr]; ok {
 				// This ctx has already been fetched, copy pointer to it.
 				newmempoolMap[txidstr] = ctx
 				continue
@@ -810,10 +822,14 @@ func (s *lwdStreamer) GetMempoolTx(exclude *walletrpc.GetMempoolTxRequest, resp 
 			tx.SetTxID(hash32.Reverse(hash32.FromSlice(txidBigEndian)))
 			newmempoolMap[txidstr] = tx.ToCompact( /* height */ 0)
 		}
+		s.mutex.Lock()
+		mempoolList = newmempoolList
 		mempoolMap = &newmempoolMap
+		s.mutex.Unlock()
+		cachedList, cachedMap = newmempoolList, newmempoolMap
 	}
-	for _, txid := range MempoolFilter(mempoolList, excludeHex) {
-		ctx, ok := (*mempoolMap)[txid]
+	for _, txid := range MempoolFilter(cachedList, excludeHex) {
+		ctx, ok := cachedMap[txid]
 		if !ok {
 			// The transaction was in getrawmempool's reply but its
 			// getrawtransaction failed (it may have been mined or evicted


### PR DESCRIPTION
Fixes **GHSA-f9pw-q493-7qvh** (reported by @dingledropper) and **GHSA-9p9r-mggr-8q9g** (reported by @Zk-nd3r), both Moderate. Developed and reviewed privately; this is the public landing.

## The problem

`GetMempoolTx` held `s.mutex` for its entire body, and two expensive things ran inside that critical section:

- **the mempool refresh** — one `getrawmempool` plus one `getrawtransaction` per newly-seen txid (GHSA-f9pw)
- **the response loop's `resp.Send` calls** — which block on the client's flow control (GHSA-9p9r)

So one caller's backend round-trips, or a single client that simply stopped reading its stream, stalled every other `GetMempoolTx` caller for as long as it took. The streaming case is unbounded, since the client decides when to read.

`GetMempoolTx` is currently the only method that takes `s.mutex`, so the stall was confined to its own concurrent callers rather than the whole gRPC service. That's a recent property rather than a design guarantee — `GetLatestBlock` held the same mutex until 5c25f20 removed it — and keeping the critical section down to the cache accesses is what keeps it true.

## The fix

The lock now covers only the shared cache. It's taken once to decide whether this call refreshes and to snapshot the current list and map, and again briefly to publish a new cache. The RPCs and the sends happen in between, unlocked.

Reading the snapshot without the lock is safe because a refresh never mutates the published map — it builds a new one and swaps the pointer — so a captured snapshot stays immutable for as long as it's used. Stamping `lastMempool` before releasing the mutex claims the refresh, so concurrent callers serve from the existing cache instead of all issuing the same RPCs.

**The refresh also now stops when the client that triggered it disconnects.** Since `RawRequest` observes the request context, without that check every remaining per-txid fetch fails once the client hangs up, each failure is swallowed by the existing "mempool transactions can disappear" path, and the handler publishes a cache missing nearly every transaction — degrading it for every other caller until the next refresh two seconds later.

Also fixes a smaller pre-existing wart: the refresh unmarshalled `getrawmempool` straight into the package-level txid list, so a refresh failing part-way left that list updated while the map still held the previous contents. Both are now built as locals and published together.

## Tests

Two, each verified to fail against the previous code rather than merely pass against the new one:

- `TestGetMempoolTxSlowClientDoesNotBlockOthers` parks one caller inside `Send` and asserts a second still completes. Against the old code it blocks for the full 10s timeout.
- `TestGetMempoolTxAbortsRefreshOnClientCancel` cancels mid-refresh and asserts the loop stops early without publishing a partial cache.

Full suite green under `-race -shuffle=on`; `gofmt` and `go vet` clean.

## Release

This PR also stages **v0.5.2**, which these fixes ship in — hence the `## [0.5.2] - 2026-07-30` CHANGELOG section rather than `[Unreleased]`.

The CHANGELOG is the only in-repo release artifact. There's no version constant to bump: the Makefile derives it at build time from ``git describe --tags`` (`-X .../common.Version=$(VERSION)`), so the tag *is* the version.

Remaining steps are all post-merge:

1. Tag `v0.5.2`
2. Create the GitHub release — note this is what ships the images: `docker_push` in `CI.yaml` runs `if: github.event_name == 'release'` and pushes `electriccoinco/lightwalletd:<tag>` and `:latest`, mirrored to `zodlinc`
3. Publish GHSA-f9pw-q493-7qvh and GHSA-9p9r-mggr-8q9g with `vulnerable <= 0.5.1` / `patched 0.5.2`

Naming the CHANGELOG section now rather than at tag time is deliberate: this repo has historically never renamed `[Unreleased]`, which is how it came to hold three releases' worth of entries by v0.5.0 (untangled there by splitting them across `[0.5.0]`, `[0.4.19]` and `[0.4.18]` based on which entries were present at each tag).
