### PR TITLE
gRPC: guarantee block continuity in GetBlockRange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The most recent changes are listed first.
 
+## [0.5.3] - 2026-08-04
+
+### Fixed
+
+- `GetBlockRange` and `GetBlockRangeNullifiers` now check that each block they
+  return connects to the one before it, and fail the stream with `Aborted`
+  rather than send a block that doesn't (GHSA-m7j5-wvx3-qj6j). Every height in
+  the range is resolved independently, from the block cache when it's present
+  there and from the backend node otherwise, so while the background ingestor
+  was still repairing a reorg, a single request spanning the cache tip could
+  return a block from the abandoned fork followed by one from the current
+  fork. That pair violates `block[n+1].prevHash == block[n].hash` and
+  describes a chain that cannot exist, which a strict wallet will reject and a
+  lenient one may briefly index against. Note that this makes each response
+  internally consistent; a range served entirely from the not-yet-repaired
+  part of the cache still returns blocks from the abandoned fork, until the
+  ingestor rewinds past them.
+
 ## [0.5.2] - 2026-07-30
 
 ### Fixed

--- a/common/common.go
+++ b/common/common.go
@@ -5,6 +5,7 @@
 package common
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"encoding/json"
@@ -607,13 +608,19 @@ func GetBlockRange(ctx context.Context, cache *BlockCache, blockOut chan<- *wall
 	// Go over [start, end] inclusive
 	low := int(span.Start.Height)
 	high := int(span.End.Height)
-	if low > high {
+	backward := low > high
+	if backward {
 		// reverse the order
 		low, high = high, low
 	}
+	// The hash that the next block must match to prove it's adjacent to the one
+	// just sent. Going forward that's the hash of the block just sent, which
+	// the next block must name as its parent; going backward it's that block's
+	// parent, which the next block must be. Nil before the first block is sent.
+	var wantHash []byte
 	for i := low; i <= high; i++ {
 		j := i
-		if span.Start.Height > span.End.Height {
+		if backward {
 			// reverse the order
 			j = high - (i - low)
 		}
@@ -626,6 +633,22 @@ func GetBlockRange(ctx context.Context, cache *BlockCache, blockOut chan<- *wall
 			}
 			return
 		}
+		// The field of this block that has to match wantHash (see above).
+		gotHash := block.PrevHash
+		if backward {
+			gotHash = block.Hash
+		}
+		if wantHash != nil && !bytes.Equal(gotHash, wantHash) {
+			// The cache and the backend disagree about the chain, which is the
+			// state the node is in while the ingestor repairs a reorg. Fail
+			// rather than serve a sequence of blocks that can't exist.
+			select {
+			case errOut <- status.Error(codes.Aborted,
+				"GetBlockRange: chain discontinuity during reorg repair"):
+			case <-ctx.Done():
+			}
+			return
+		}
 		block.Vtx = filterBlockPool(block.Vtx, span.PoolTypes)
 
 		// Note that we do want to return blocks that have had all of its transactions filtered,
@@ -634,6 +657,10 @@ func GetBlockRange(ctx context.Context, cache *BlockCache, blockOut chan<- *wall
 		case blockOut <- block:
 		case <-ctx.Done():
 			return
+		}
+		wantHash = block.Hash
+		if backward {
+			wantHash = block.PrevHash
 		}
 	}
 	select {

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -17,7 +18,10 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/zcash/lightwalletd/parser"
 	"github.com/zcash/lightwalletd/walletrpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // ------------------------------------------ Setup
@@ -523,6 +527,197 @@ func TestGetBlockRange(t *testing.T) {
 		t.Fatal("unexpected step:", step)
 	}
 	os.RemoveAll(unitTestPath)
+}
+
+// staleForkCache returns a cache holding a single height-380640 block from a
+// fork that the backend has since reorged away from. Its hash is arbitrary;
+// all that matters is that it differs from the hash of the real height-380640
+// block, which is what the real height-380641 block (blocks[1], served by
+// discontinuityStub below) names as its PrevHash.
+//
+// This is the state described in GHSA-m7j5-wvx3-qj6j: the background ingestor
+// hasn't yet rewound the cache, so a range that spans the cache/backend
+// boundary would mix two forks.
+func staleForkCache(t *testing.T) *BlockCache {
+	os.RemoveAll(unitTestPath)
+	cache := NewBlockCache(unitTestPath, unitTestChain, 380640, 0)
+	err := cache.Add(380640, &walletrpc.CompactBlock{
+		Height:   380640,
+		Hash:     bytes.Repeat([]byte{0xa1}, 32),
+		PrevHash: bytes.Repeat([]byte{0xa0}, 32),
+	})
+	if err != nil {
+		t.Fatal("cache.Add failed:", err)
+	}
+	return cache
+}
+
+// discontinuityStub serves only height 380641; height 380640 is satisfied from
+// the cache, so it's never requested from the backend.
+func discontinuityStub(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
+	if method != "getblock" {
+		testT.Error("unexpected method")
+	}
+	var arg string
+	if err := json.Unmarshal(params[0], &arg); err != nil {
+		testT.Fatal("could not unmarshal height")
+	}
+
+	step++
+	switch step {
+	case 1:
+		if arg != "380641" {
+			testT.Error("unexpected height")
+		}
+		return []byte("{\"Tx\": [\"" + testTxid + "\"], \"Hash\": \"" + testBlockid41 + "\"}"), nil
+	case 2:
+		if arg != testBlockid41 {
+			testT.Error("unexpected hash")
+		}
+		return blocks[1], nil
+	}
+	testT.Error("discontinuityStub called too many times")
+	return nil, nil
+}
+
+// checkDiscontinuity requires that the next thing GetBlockRange produces is the
+// discontinuity error, rather than another block.
+func checkDiscontinuity(t *testing.T, blockChan <-chan *walletrpc.CompactBlock, errChan <-chan error) {
+	t.Helper()
+	select {
+	case err := <-errChan:
+		if status.Code(err) != codes.Aborted {
+			t.Fatal("unexpected error code:", status.Code(err), err)
+		}
+		if !strings.Contains(err.Error(), "chain discontinuity") {
+			t.Fatal("unexpected error:", err)
+		}
+	case cBlock := <-blockChan:
+		t.Fatal("streamed a block that doesn't connect, height:", cBlock.Height)
+	}
+}
+
+// A range that spans a stale cached block and the current backend block must
+// fail rather than stream a chain that can't exist.
+func TestGetBlockRangeDiscontinuity(t *testing.T) {
+	testT = t
+	RawRequest = discontinuityStub
+	defer resetGlobals()
+	testcache = staleForkCache(t)
+	defer os.RemoveAll(unitTestPath)
+
+	blockChan := make(chan *walletrpc.CompactBlock)
+	errChan := make(chan error)
+	blockRange := &walletrpc.BlockRange{
+		Start: &walletrpc.BlockID{Height: 380640},
+		End:   &walletrpc.BlockID{Height: 380641},
+	}
+	go GetBlockRange(context.Background(), testcache, blockChan, errChan, blockRange)
+
+	// The stale 380640 goes out before there's anything to compare it
+	// against; the mismatch can only be detected once 380641 arrives.
+	select {
+	case err := <-errChan:
+		t.Fatal("unexpected error:", err)
+	case cBlock := <-blockChan:
+		if cBlock.Height != 380640 {
+			t.Fatal("unexpected Height:", cBlock.Height)
+		}
+	}
+
+	// blocks[1].PrevHash is the real 380640 hash, not the stale one.
+	checkDiscontinuity(t, blockChan, errChan)
+
+	if step != 2 {
+		t.Fatal("unexpected step:", step)
+	}
+}
+
+// Same as TestGetBlockRangeDiscontinuity, but with start greater than end, so
+// the blocks are compared in the other direction.
+func TestGetBlockRangeDiscontinuityReverse(t *testing.T) {
+	testT = t
+	RawRequest = discontinuityStub
+	defer resetGlobals()
+	testcache = staleForkCache(t)
+	defer os.RemoveAll(unitTestPath)
+
+	blockChan := make(chan *walletrpc.CompactBlock)
+	errChan := make(chan error)
+	blockRange := &walletrpc.BlockRange{
+		Start: &walletrpc.BlockID{Height: 380641},
+		End:   &walletrpc.BlockID{Height: 380640},
+	}
+	go GetBlockRange(context.Background(), testcache, blockChan, errChan, blockRange)
+
+	// read in block 380641 (from the backend, the current fork)
+	select {
+	case err := <-errChan:
+		t.Fatal("unexpected error:", err)
+	case cBlock := <-blockChan:
+		if cBlock.Height != 380641 {
+			t.Fatal("unexpected Height:", cBlock.Height)
+		}
+	}
+
+	// The stale cached 380640 isn't the block that 380641 descends from.
+	checkDiscontinuity(t, blockChan, errChan)
+
+	if step != 2 {
+		t.Fatal("unexpected step:", step)
+	}
+}
+
+// The same cache/backend split, but with a cached block that really is the
+// parent of the backend's block: the range must stream normally. Without this,
+// nothing covers the happy path across the cache/backend boundary, which is
+// every wallet syncing at the cache tip.
+func TestGetBlockRangeContiguousReverse(t *testing.T) {
+	testT = t
+	RawRequest = discontinuityStub
+	defer resetGlobals()
+	os.RemoveAll(unitTestPath)
+	defer os.RemoveAll(unitTestPath)
+	testcache = NewBlockCache(unitTestPath, unitTestChain, 380640, 0)
+
+	// Cache the real 380640, the block that the backend's 380641 descends from.
+	block := parser.NewBlock()
+	var blockHex string
+	if err := json.Unmarshal(blocks[0], &blockHex); err != nil {
+		t.Fatal("could not unmarshal test block:", err)
+	}
+	blockBytes, err := hex.DecodeString(blockHex)
+	if err != nil {
+		t.Fatal("could not decode test block:", err)
+	}
+	if _, err := block.ParseFromSlice(blockBytes); err != nil {
+		t.Fatal("could not parse test block:", err)
+	}
+	if err := testcache.Add(380640, block.ToCompact()); err != nil {
+		t.Fatal("cache.Add failed:", err)
+	}
+
+	blockChan := make(chan *walletrpc.CompactBlock)
+	errChan := make(chan error)
+	blockRange := &walletrpc.BlockRange{
+		Start: &walletrpc.BlockID{Height: 380641},
+		End:   &walletrpc.BlockID{Height: 380640},
+	}
+	go GetBlockRange(context.Background(), testcache, blockChan, errChan, blockRange)
+
+	for _, height := range []uint64{380641, 380640} {
+		select {
+		case err := <-errChan:
+			t.Fatal("unexpected error:", err)
+		case cBlock := <-blockChan:
+			if cBlock.Height != height {
+				t.Fatal("unexpected Height:", cBlock.Height)
+			}
+		}
+	}
+	if err := <-errChan; err != nil {
+		t.Fatal("unexpected error:", err)
+	}
 }
 
 func TestGetBlockRangeCancelsInFlightRPC(t *testing.T) {


### PR DESCRIPTION
`GetBlockRange` resolves each height in the requested range independently, taking the block from the cache when it's present there and from the backend node otherwise. Those two sources agree except while the background ingestor is repairing a reorg: until it has rewound the cache, the cache holds blocks from the abandoned fork while the backend has already moved to the new one. A range spanning the cache tip could then return a block from the old fork followed by one from the new — a pair whose hashes don't link, describing a chain that never existed.

This tracks the hash that the next block has to present (going forward, the hash of the block just sent, which the next block must name as its parent; going backward, that block's parent, which the next block must be) and aborts the stream with `Aborted` rather than send a block that doesn't match.

`GetBlockRangeNullifiers` shares `common.GetBlockRange`, so it's covered too.

### Scope

This makes each *response* internally consistent. It does not prevent a range served entirely from the not-yet-repaired part of the cache from returning blocks from the abandoned fork — that resolves when the ingestor rewinds past them.

### Notes for review

- **Direction.** The reverse case (`Start` > `End`) is the easy one to get backwards. Both directions are covered by tests, and I checked by mutation that each fails if the comparison is written the wrong way round.
- **Darkside is unaffected.** `setPrevhash` (`common/darkside.go:254`) rewires prevhash across the whole active chain on every apply, so staged reorgs can't trip the check.
- **Retaining the hash across the loop is safe.** Only 32 bytes are kept, not the block; and `pruneCompactBlockToNullifiers` — the one consumer that mutates what it receives — touches only `Vtx` and `ChainMetadata`, never `Hash`/`PrevHash`.
- **New error path.** Clients will see a stream fail mid-range and must retry, which they already have to tolerate for network failures.

### Tests

Three tests in `common/common_test.go` after `TestGetBlockRange`, set up as the real thing rather than hand-fed to the checker: the cache holds a height-380640 block from an abandoned fork, the backend serves the genuine 380641 whose `PrevHash` names the *real* 380640.

- `TestGetBlockRangeDiscontinuity` — forward
- `TestGetBlockRangeDiscontinuityReverse` — same fixture, `Start` > `End`
- `TestGetBlockRangeContiguousReverse` — cached block really is the parent, so the range must stream normally; guards the happy path across the cache/backend boundary, which is every wallet syncing at the cache tip

Verified by mutation that the suite catches the check being disabled, either direction branch being dropped, and the direction flag being inverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)