### PR TITLE
frontend: deduplicate client-supplied address lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,30 @@ The most recent changes are listed first.
   The value is a constant tracking the vendored `lightwallet-protocol`
   subtree, currently v0.5.0, and is not overwritten by the build.
 
+- `GetTaddressBalance` and `GetTaddressBalanceStream` no longer report an
+  inflated balance when the client names the same address more than once.
+  zcashd's `getaddressbalance` sums over the list entries, so a repeated
+  address was counted repeatedly; a doubled address returned exactly twice the
+  correct balance. zebrad collapses duplicates before querying, so the same
+  request returned different numbers depending on which backend lightwalletd
+  was configured with. The address list is now deduplicated before the backend
+  call, so the reported balance is the balance of the distinct addresses named,
+  on any backend.
+
+- `GetAddressUtxos` and `GetAddressUtxosStream` now collapse repeated
+  addresses before calling the backend, so a request naming one address n times
+  no longer asks the backend to look it up n times and return n copies of its
+  UTXOs. Against zcashd that was a real multiplier — repeating an address is
+  free to the caller, since addresses are public and neither a key nor any
+  funds are needed to name one, so a single request could multiply the busiest
+  address on the chain by the 10,000-address limit. zebrad already collapses
+  duplicates before querying its state, so it was never exposed to this;
+  lightwalletd no longer depends on the backend to do it. This narrows the
+  worst case rather than closing it: `StartHeight` and `MaxEntries` remain
+  response filters applied after the whole backend result is materialized, so
+  the UTXO set of even a single named address is still fetched in full
+  (GHSA-x4m7-3gpp-xc36).
+
 ## [0.5.3] - 2026-08-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The most recent changes are listed first.
 
+## [Unreleased]
+
+### Fixed
+
+- `GetTaddressBalance` and `GetTaddressBalanceStream` no longer report an
+  inflated balance when the client names the same address more than once.
+  zcashd's `getaddressbalance` sums over the list entries, so a repeated
+  address was counted repeatedly; a doubled address returned exactly twice the
+  correct balance. zebrad collapses duplicates before querying, so the same
+  request returned different numbers depending on which backend lightwalletd
+  was configured with. The address list is now deduplicated before the backend
+  call, so the reported balance is the balance of the distinct addresses named,
+  on any backend.
+
+- `GetAddressUtxos` and `GetAddressUtxosStream` now collapse repeated
+  addresses before calling the backend, so a request naming one address n times
+  no longer asks the backend to look it up n times and return n copies of its
+  UTXOs. Against zcashd that was a real multiplier — repeating an address is
+  free to the caller, since addresses are public and neither a key nor any
+  funds are needed to name one, so a single request could multiply the busiest
+  address on the chain by the 10,000-address limit. zebrad already collapses
+  duplicates before querying its state, so it was never exposed to this;
+  lightwalletd no longer depends on the backend to do it. This narrows the
+  worst case rather than closing it: `StartHeight` and `MaxEntries` remain
+  response filters applied after the whole backend result is materialized, so
+  the UTXO set of even a single named address is still fetched in full
+  (GHSA-x4m7-3gpp-xc36).
+
 ## [0.5.3] - 2026-08-04
 
 ### Fixed

--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -461,6 +462,162 @@ func TestGetAddressUtxosTooManyAddresses(t *testing.T) {
 	}
 	if status.Code(err) != codes.ResourceExhausted {
 		t.Fatal("expected ResourceExhausted on too many addresses, got:", err)
+	}
+}
+
+func TestGetTaddressBalanceDeduplicates(t *testing.T) {
+	testT = t
+	defer resetGlobals()
+	lwd, _ := testsetup()
+
+	taddr := func(c string) string { return "t1" + strings.Repeat(c, 33) }
+	addrA, addrB := taddr("a"), taddr("b")
+
+	// zcashd sums getaddressbalance over the list entries, so a repeated
+	// address inflates the balance it reports; zebrad collapses duplicates
+	// before querying. Model zcashd here: 1000 zats per entry received.
+	var forwarded []string
+	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
+		if method != "getaddressbalance" {
+			testT.Fatal("unexpected method", method)
+		}
+		var req common.ZcashdRpcRequestGetaddressbalance
+		if err := json.Unmarshal(params[0], &req); err != nil {
+			testT.Fatal("could not unmarshal getaddressbalance request")
+		}
+		forwarded = req.Addresses
+		return json.Marshal(common.ZcashdRpcReplyGetaddressbalance{
+			Balance: int64(1000 * len(req.Addresses)),
+		})
+	}
+
+	balance, err := lwd.GetTaddressBalance(context.Background(),
+		&walletrpc.AddressList{Addresses: []string{addrA, addrB, addrA, addrA}})
+	if err != nil {
+		t.Fatal("GetTaddressBalance failed:", err)
+	}
+	if !reflect.DeepEqual(forwarded, []string{addrA, addrB}) {
+		t.Fatal("expected the distinct addresses in first-occurrence order, got:", forwarded)
+	}
+	// Two distinct addresses, so two entries' worth -- not four.
+	if balance.ValueZat != 2000 {
+		t.Fatal("expected balance 2000, got:", balance.ValueZat)
+	}
+}
+
+func TestGetTaddressBalanceEmptyList(t *testing.T) {
+	testT = t
+	defer resetGlobals()
+	lwd, _ := testsetup()
+
+	// An empty address list is not an error; the balance of nothing is zero.
+	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
+		if method != "getaddressbalance" {
+			testT.Fatal("unexpected method", method)
+		}
+		return json.Marshal(common.ZcashdRpcReplyGetaddressbalance{Balance: 0})
+	}
+
+	balance, err := lwd.GetTaddressBalance(context.Background(), &walletrpc.AddressList{})
+	if err != nil {
+		t.Fatal("GetTaddressBalance failed on an empty address list:", err)
+	}
+	if balance.ValueZat != 0 {
+		t.Fatal("expected balance 0, got:", balance.ValueZat)
+	}
+}
+
+func TestGetAddressUtxosEmptyList(t *testing.T) {
+	testT = t
+	defer resetGlobals()
+	lwd, _ := testsetup()
+
+	// An empty address list is not an error; it selects no utxos.
+	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
+		if method != "getaddressutxos" {
+			testT.Fatal("unexpected method", method)
+		}
+		return json.Marshal([]common.ZcashdRpcReplyGetaddressutxos{})
+	}
+
+	reply, err := lwd.GetAddressUtxos(context.Background(), &walletrpc.GetAddressUtxosArg{})
+	if err != nil {
+		t.Fatal("GetAddressUtxos failed on an empty address list:", err)
+	}
+	if len(reply.AddressUtxos) != 0 {
+		t.Fatal("expected no utxos, got:", len(reply.AddressUtxos))
+	}
+}
+
+func TestGetAddressUtxosDeduplicates(t *testing.T) {
+	testT = t
+	defer resetGlobals()
+	lwd, _ := testsetup()
+
+	// A distinct valid taddr per letter: "t1" followed by 33 more characters.
+	taddr := func(c string) string { return "t1" + strings.Repeat(c, 33) }
+	addrA, addrB, addrC := taddr("a"), taddr("b"), taddr("c")
+	addrD, addrE, addrF := taddr("d"), taddr("e"), taddr("f")
+
+	// zcashd looks up each entry of the address list independently, so a
+	// repeated address multiplies its backend cost and its UTXOs in the reply.
+	// Repeating an address costs the caller nothing, so lightwalletd must send
+	// each distinct address once, in first-occurrence order. Six addresses so
+	// that an implementation collecting them out of order (from a map, say)
+	// reliably fails this rather than matching by chance.
+	var forwarded []string
+	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
+		if method != "getaddressutxos" {
+			testT.Fatal("unexpected method", method)
+		}
+		var req common.ZcashdRpcRequestGetaddressutxos
+		if err := json.Unmarshal(params[0], &req); err != nil {
+			testT.Fatal("could not unmarshal getaddressutxos request")
+		}
+		forwarded = req.Addresses
+		return json.Marshal([]common.ZcashdRpcReplyGetaddressutxos{{
+			Address:     addrA,
+			Txid:        "0788e4dc9973cd9a54e0f4d51ec96f4b8e6a8e0f8a1e1e9e4b2c2a1d0e0f0a0b",
+			OutputIndex: 0,
+			Script:      "76a914000000000000000000000000000000000000000088ac",
+			Satoshis:    1000,
+			Height:      1234,
+		}})
+	}
+
+	// Duplicates interleaved with the distinct addresses, and one address
+	// (addrA) repeated far more often than the rest.
+	reply, err := lwd.GetAddressUtxos(context.Background(), &walletrpc.GetAddressUtxosArg{
+		Addresses: []string{
+			addrA, addrB, addrA, addrC, addrB, addrA,
+			addrD, addrA, addrE, addrD, addrF, addrA,
+		},
+	})
+	if err != nil {
+		t.Fatal("GetAddressUtxos failed:", err)
+	}
+	want := []string{addrA, addrB, addrC, addrD, addrE, addrF}
+	if !reflect.DeepEqual(forwarded, want) {
+		t.Fatal("expected the distinct addresses in first-occurrence order, got:", forwarded)
+	}
+	if len(reply.AddressUtxos) != 1 {
+		t.Fatal("expected one utxo, got:", len(reply.AddressUtxos))
+	}
+
+	// An invalid address is still rejected, even if a valid one precedes it,
+	// and even though the dedupe check runs first.
+	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
+		testT.Fatal("zcashd must not be called for an invalid address")
+		return nil, nil
+	}
+	_, err = lwd.GetAddressUtxos(context.Background(), &walletrpc.GetAddressUtxosArg{
+		Addresses: []string{addrA, addrA, "not-a-valid-address"},
+	})
+	if err == nil {
+		t.Fatal("GetAddressUtxos should have failed on bad address")
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatal("expected InvalidArgument on bad address, got:", err)
 	}
 }
 

--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -407,6 +408,118 @@ func TestGetAddressUtxosTooManyAddresses(t *testing.T) {
 	}
 	if status.Code(err) != codes.ResourceExhausted {
 		t.Fatal("expected ResourceExhausted on too many addresses, got:", err)
+	}
+}
+
+func TestGetTaddressBalanceDeduplicates(t *testing.T) {
+	testT = t
+	defer resetGlobals()
+	lwd, _ := testsetup()
+
+	taddr := func(c string) string { return "t1" + strings.Repeat(c, 33) }
+	addrA, addrB := taddr("a"), taddr("b")
+
+	// zcashd sums getaddressbalance over the list entries, so a repeated
+	// address inflates the balance it reports; zebrad collapses duplicates
+	// before querying. Model zcashd here: 1000 zats per entry received.
+	var forwarded []string
+	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
+		if method != "getaddressbalance" {
+			testT.Fatal("unexpected method", method)
+		}
+		var req common.ZcashdRpcRequestGetaddressbalance
+		if err := json.Unmarshal(params[0], &req); err != nil {
+			testT.Fatal("could not unmarshal getaddressbalance request")
+		}
+		forwarded = req.Addresses
+		return json.Marshal(common.ZcashdRpcReplyGetaddressbalance{
+			Balance: int64(1000 * len(req.Addresses)),
+		})
+	}
+
+	balance, err := lwd.GetTaddressBalance(context.Background(),
+		&walletrpc.AddressList{Addresses: []string{addrA, addrB, addrA, addrA}})
+	if err != nil {
+		t.Fatal("GetTaddressBalance failed:", err)
+	}
+	if !reflect.DeepEqual(forwarded, []string{addrA, addrB}) {
+		t.Fatal("expected the distinct addresses in first-occurrence order, got:", forwarded)
+	}
+	// Two distinct addresses, so two entries' worth -- not four.
+	if balance.ValueZat != 2000 {
+		t.Fatal("expected balance 2000, got:", balance.ValueZat)
+	}
+}
+
+func TestGetAddressUtxosDeduplicates(t *testing.T) {
+	testT = t
+	defer resetGlobals()
+	lwd, _ := testsetup()
+
+	// A distinct valid taddr per letter: "t1" followed by 33 more characters.
+	taddr := func(c string) string { return "t1" + strings.Repeat(c, 33) }
+	addrA, addrB, addrC := taddr("a"), taddr("b"), taddr("c")
+	addrD, addrE, addrF := taddr("d"), taddr("e"), taddr("f")
+
+	// zcashd looks up each entry of the address list independently, so a
+	// repeated address multiplies its backend cost and its UTXOs in the reply.
+	// Repeating an address costs the caller nothing, so lightwalletd must send
+	// each distinct address once, in first-occurrence order. Six addresses so
+	// that an implementation collecting them out of order (from a map, say)
+	// reliably fails this rather than matching by chance.
+	var forwarded []string
+	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
+		if method != "getaddressutxos" {
+			testT.Fatal("unexpected method", method)
+		}
+		var req common.ZcashdRpcRequestGetaddressutxos
+		if err := json.Unmarshal(params[0], &req); err != nil {
+			testT.Fatal("could not unmarshal getaddressutxos request")
+		}
+		forwarded = req.Addresses
+		return json.Marshal([]common.ZcashdRpcReplyGetaddressutxos{{
+			Address:     addrA,
+			Txid:        "0788e4dc9973cd9a54e0f4d51ec96f4b8e6a8e0f8a1e1e9e4b2c2a1d0e0f0a0b",
+			OutputIndex: 0,
+			Script:      "76a914000000000000000000000000000000000000000088ac",
+			Satoshis:    1000,
+			Height:      1234,
+		}})
+	}
+
+	// Duplicates interleaved with the distinct addresses, and one address
+	// (addrA) repeated far more often than the rest.
+	reply, err := lwd.GetAddressUtxos(context.Background(), &walletrpc.GetAddressUtxosArg{
+		Addresses: []string{
+			addrA, addrB, addrA, addrC, addrB, addrA,
+			addrD, addrA, addrE, addrD, addrF, addrA,
+		},
+	})
+	if err != nil {
+		t.Fatal("GetAddressUtxos failed:", err)
+	}
+	want := []string{addrA, addrB, addrC, addrD, addrE, addrF}
+	if !reflect.DeepEqual(forwarded, want) {
+		t.Fatal("expected the distinct addresses in first-occurrence order, got:", forwarded)
+	}
+	if len(reply.AddressUtxos) != 1 {
+		t.Fatal("expected one utxo, got:", len(reply.AddressUtxos))
+	}
+
+	// An invalid address is still rejected, even if a valid one precedes it,
+	// and even though the dedupe check runs first.
+	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
+		testT.Fatal("zcashd must not be called for an invalid address")
+		return nil, nil
+	}
+	_, err = lwd.GetAddressUtxos(context.Background(), &walletrpc.GetAddressUtxosArg{
+		Addresses: []string{addrA, addrA, "not-a-valid-address"},
+	})
+	if err == nil {
+		t.Fatal("GetAddressUtxos should have failed on bad address")
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatal("expected InvalidArgument on bad address, got:", err)
 	}
 }
 

--- a/frontend/service.go
+++ b/frontend/service.go
@@ -586,14 +586,23 @@ func getTaddressBalanceZcashdRpc(ctx context.Context, addressList []string) (*wa
 		return nil, status.Errorf(codes.ResourceExhausted,
 			"getTaddressBalanceZcashdRpc: too many addresses (limit %d)", maxTaddrsPerRequest)
 	}
+	// Eliminate duplicate addresses; zcashd sums per list entry, so a repeated
+	// address would otherwise inflate the balance it reports.
+	addresses := make([]string, 0)
+	seen := make(map[string]struct{})
 	for _, addr := range addressList {
+		if _, dup := seen[addr]; dup {
+			continue
+		}
 		if err := checkTaddress(addr); err != nil {
 			return nil, err
 		}
+		seen[addr] = struct{}{}
+		addresses = append(addresses, addr)
 	}
 	params := make([]json.RawMessage, 1)
 	addrList := &common.ZcashdRpcRequestGetaddressbalance{
-		Addresses: addressList,
+		Addresses: addresses,
 	}
 	param, err := json.Marshal(addrList)
 	if err != nil {
@@ -890,22 +899,26 @@ func MempoolFilter(items, exclude []string) []string {
 }
 
 func getAddressUtxos(ctx context.Context, arg *walletrpc.GetAddressUtxosArg, f func(*walletrpc.GetAddressUtxosReply) error) error {
-	// Bound the address count before contacting zcashd: getaddressutxos cannot
-	// push down StartHeight/MaxEntries, so lightwalletd fetches and
-	// materializes the entire backend result before applying those limits.
-	// Capping the input keeps one request from forcing unbounded backend work
-	// and result materialization (GHSA-x4m7-3gpp-xc36).
+	// GHSA-x4m7-3gpp-xc36
 	if len(arg.Addresses) > maxTaddrsPerRequest {
 		return status.Errorf(codes.ResourceExhausted,
 			"getAddressUtxos: too many addresses (limit %d)", maxTaddrsPerRequest)
 	}
+	// Eliminate duplicate addresses; returned UTXO set doesn't change.
+	addresses := make([]string, 0)
+	seen := make(map[string]struct{})
 	for _, a := range arg.Addresses {
+		if _, dup := seen[a]; dup {
+			continue
+		}
 		if err := checkTaddress(a); err != nil {
 			return err
 		}
+		seen[a] = struct{}{}
+		addresses = append(addresses, a)
 	}
 	addrList := &common.ZcashdRpcRequestGetaddressutxos{
-		Addresses: arg.Addresses,
+		Addresses: addresses,
 	}
 	param, err := json.Marshal(addrList)
 	if err != nil {

--- a/frontend/service.go
+++ b/frontend/service.go
@@ -581,14 +581,23 @@ func (s *lwdStreamer) SendTransaction(ctx context.Context, rawtx *walletrpc.RawT
 }
 
 func getTaddressBalanceZcashdRpc(ctx context.Context, addressList []string) (*walletrpc.Balance, error) {
+	// Eliminate duplicate addresses; zcashd sums per list entry, so a repeated
+	// address would otherwise inflate the balance it reports.
+	addresses := make([]string, 0, len(addressList))
+	seen := make(map[string]struct{}, len(addressList))
 	for _, addr := range addressList {
+		if _, dup := seen[addr]; dup {
+			continue
+		}
 		if err := checkTaddress(addr); err != nil {
 			return nil, err
 		}
+		seen[addr] = struct{}{}
+		addresses = append(addresses, addr)
 	}
 	params := make([]json.RawMessage, 1)
 	addrList := &common.ZcashdRpcRequestGetaddressbalance{
-		Addresses: addressList,
+		Addresses: addresses,
 	}
 	param, err := json.Marshal(addrList)
 	if err != nil {
@@ -886,22 +895,26 @@ func MempoolFilter(items, exclude []string) []string {
 }
 
 func getAddressUtxos(ctx context.Context, arg *walletrpc.GetAddressUtxosArg, f func(*walletrpc.GetAddressUtxosReply) error) error {
-	// Bound the address count before contacting zcashd: getaddressutxos cannot
-	// push down StartHeight/MaxEntries, so lightwalletd fetches and
-	// materializes the entire backend result before applying those limits.
-	// Capping the input keeps one request from forcing unbounded backend work
-	// and result materialization (GHSA-x4m7-3gpp-xc36).
+	// GHSA-x4m7-3gpp-xc36
 	if len(arg.Addresses) > maxTaddrsPerRequest {
 		return status.Errorf(codes.ResourceExhausted,
 			"getAddressUtxos: too many addresses (limit %d)", maxTaddrsPerRequest)
 	}
+	// Eliminate duplicate addresses; returned UTXO set doesn't change.
+	addresses := make([]string, 0, len(arg.Addresses))
+	seen := make(map[string]struct{}, len(arg.Addresses))
 	for _, a := range arg.Addresses {
+		if _, dup := seen[a]; dup {
+			continue
+		}
 		if err := checkTaddress(a); err != nil {
 			return err
 		}
+		seen[a] = struct{}{}
+		addresses = append(addresses, a)
 	}
 	addrList := &common.ZcashdRpcRequestGetaddressutxos{
-		Addresses: arg.Addresses,
+		Addresses: addresses,
 	}
 	param, err := json.Marshal(addrList)
 	if err != nil {


### PR DESCRIPTION
The transparent-address methods pass the client's address list to the backend unchanged, and the two backends treat repeats differently.

## `getaddressbalance` — a wrong number, not just a slow one

zcashd sums over the list entries, so a repeated address is counted repeatedly. Verified against zcashd master: the same address listed twice returned `100365254620` zats against `50182627310` listed once — exactly double.

zebrad parses the list into a `HashSet<Address>` before querying ([`methods.rs:3798`](https://github.com/ZcashFoundation/zebra/blob/main/zebra-rpc/src/methods.rs)), so duplicates collapse and it reports the balance of the distinct addresses.

So the same request returned different balances depending on which backend lightwalletd was configured with, and the zcashd answer was wrong. **This is a correctness fix, and it changes returned balances against a zcashd backend.**

It is not a security issue: a client can only mislead itself this way, not inflate anyone else's balance.

## `getaddressutxos` — a resource multiplier

Same split. zcashd looks up each entry independently and returned 250 UTXOs for an address listed twice that yields 125 listed once; zebrad returns the same set either way. Repeating an address costs the caller nothing — addresses are public, and neither a key nor any funds are needed to name one — so against a zcashd backend a single request could multiply the busiest address on the chain by `maxTaddrsPerRequest` (10,000).

zebrad was never exposed to this. The point of fixing it in lightwalletd is that lightwalletd shouldn't depend on backend behavior to bound work it can bound itself — the same layering argument as validating input locally.

## Details

- Both lists are deduplicated before the backend call, keeping first occurrence, so the order the backend sees is unchanged.
- For UTXOs the cap is applied to the raw list first, then dedupe, so the 10,000 limit remains a bound on input size and can't be slipped past with duplicates.
- The dup check runs before `checkTaddress`, so validation happens once per distinct address rather than once per entry. An invalid address is still rejected, since its first occurrence reaches the check.
- `GetTaddressTransactions` and `GetTaddressTxids` carry a single `address` field, so they can't receive duplicates and are unaffected.

## Scope

The UTXO change narrows the worst case; it does not close it. `StartHeight` and `MaxEntries` are still response filters applied after the entire backend result has been fetched and unmarshalled, so a single named address with a large UTXO set is bounded by nothing here — and that case is unaffected by deduplication. That residual is the unremediated part of GHSA-x4m7-3gpp-xc36 and needs range/limit arguments pushed down into the backend RPC to close.

## Testing

`TestGetTaddressBalanceDeduplicates` uses a stub that returns 1000 zats per list entry it receives — modelling zcashd — and asserts that four entries naming two distinct addresses yield 2000, not 4000.

`TestGetAddressUtxosDeduplicates` asserts the backend receives exactly the distinct addresses in first-occurrence order, and that an invalid address following duplicates still yields `InvalidArgument`.

Mutation-tested: bypassing either dedupe fails its test, and a variant that deduplicates without preserving order fails 8/8 runs (six addresses are used specifically so map iteration can't match by chance).
