### PR TITLE
ci: fix crane invocation in the zodlinc mirror push

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -72,12 +72,14 @@ jobs:
           DST_PASS: ${{ secrets.ZODLINC_DOCKERHUB_PASSWORD }}
         run: |
           TAG="${{ github.event.release.tag_name }}"
-          go install github.com/google/go-containerregistry/cmd/crane@latest
-          crane copy \
+          go install github.com/google/go-containerregistry/cmd/crane@v0.21.8
+          # go install writes to GOPATH/bin, which is not on PATH in this job.
+          CRANE="$(go env GOPATH)/bin/crane"
+          "${CRANE}" copy \
             --src-creds "${SRC_USER}:${SRC_PASS}" \
             --dst-creds "${DST_USER}:${DST_PASS}" \
             electriccoinco/lightwalletd:${TAG} zodlinc/lightwalletd:${TAG}
-          crane copy \
+          "${CRANE}" copy \
             --src-creds "${SRC_USER}:${SRC_PASS}" \
             --dst-creds "${DST_USER}:${DST_PASS}" \
             electriccoinco/lightwalletd:latest zodlinc/lightwalletd:latest


### PR DESCRIPTION
The `docker_push` job's zodlinc mirror step fails with `crane: command not
found` (exit 127). `go install` writes the binary to `GOPATH/bin`, and this job
has no `actions/setup-go` step to add that directory to `PATH`, so the install
succeeds and the very next line can't find what it just installed.

Fixed by invoking crane through an absolute path.

## Impact

The step only runs on `release` events, so v0.5.3 was its first execution since
it was added in #572 — it has never once succeeded. The zodlinc mirror has been
pushed by hand in the meantime.

The `electriccoinco` push is a separate, earlier step using
`docker/build-push-action`, and was not affected. Both `v0.5.3` and `latest`
went out normally at 22:08 UTC on 2026-08-04; only the mirror was missed.

Failing run: https://github.com/zcash/lightwalletd/actions/runs/30955064832/job/92146290557

## Also pinned crane

`@latest` meant this step downloaded and executed whatever crane had been
published at that moment, inside a job holding Docker Hub push credentials for
two organizations. Pinned to `v0.21.8`, the version the failing run resolved.

## Testing

None possible before the fact — the step is gated on `github.event_name ==
'release'`, so it can't be exercised by CI on a PR, and it will next run when
v0.5.4 is released. Worth a careful read rather than trusting a green check.