### PR TITLE
common: report lightwalletProtocolVersion in GetLightdInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The most recent changes are listed first.
 
+## [Unreleased]
+
+### Fixed
+
+- Report `lightwalletProtocolVersion` in `GetLightdInfo`. The field was added
+  to `LightdInfo` in lightwallet-protocol v0.4.0, in the same release as
+  `BlockRange.poolTypes`, and is the signal clients are required to check
+  before requesting non-default pool types. lightwalletd never populated it,
+  so it was always the empty string, and a client following that rule could
+  not tell a server that serves transparent and Ironwood data inside compact
+  blocks from one that does not. Correctly-behaving clients therefore had to
+  fall back to shielded-only scanning, or rely on an out-of-band assertion
+  from the operator, against servers that had supported the data since 0.5.0.
+  The value is a constant tracking the vendored `lightwallet-protocol`
+  subtree, currently v0.5.0, and is not overwritten by the build.
+
 ## [0.5.3] - 2026-08-04
 
 ### Fixed

--- a/common/common.go
+++ b/common/common.go
@@ -35,6 +35,19 @@ var (
 	DonationAddress = ""
 )
 
+// LightwalletProtocolVersion is the version of
+// https://github.com/zcash/lightwallet-protocol that this server implements,
+// reported to clients in LightdInfo.
+//
+// It describes the protocol served, not the build, so unlike the variables
+// above it is a constant and is not overwritten by 'make build'. Clients rely
+// on it to decide whether they may request non-default `poolTypes` (that field
+// and this one were added together, in protocol v0.4.0), so it must be updated
+// in lockstep with the lightwallet-protocol subtree under
+// lightwallet-protocol/ - and only once the server actually serves everything
+// the named version specifies.
+const LightwalletProtocolVersion = "v0.5.0"
+
 type Options struct {
 	GRPCBindAddr        string `json:"grpc_bind_address,omitempty"`
 	GRPCLogging         bool   `json:"grpc_logging_insecure,omitempty"`
@@ -326,6 +339,8 @@ func GetLightdInfo() (*walletrpc.LightdInfo, error) {
 		DonationAddress:         DonationAddress,
 		UpgradeName:             upgrade.Name,
 		UpgradeHeight:           uint64(upgrade.ActivationHeight),
+
+		LightwalletProtocolVersion: LightwalletProtocolVersion,
 	}, nil
 }
 

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -215,6 +215,15 @@ func TestGetLightdInfo(t *testing.T) {
 	if getLightdInfo.DonationAddress != "ua1234test" {
 		t.Error("unexpected DonationAddress", getLightdInfo.DonationAddress)
 	}
+	// Clients are required to check this before requesting non-default
+	// poolTypes, so an empty value tells them transparent data is unavailable
+	// even though this server serves it.
+	if getLightdInfo.LightwalletProtocolVersion != LightwalletProtocolVersion {
+		t.Error("unexpected LightwalletProtocolVersion", getLightdInfo.LightwalletProtocolVersion)
+	}
+	if getLightdInfo.LightwalletProtocolVersion == "" {
+		t.Error("LightwalletProtocolVersion must not be empty")
+	}
 	// If more than one network upgrade is pending, the closest
 	// (next) should be reported.
 	if getLightdInfo.UpgradeName != "b" {


### PR DESCRIPTION
LightdInfo.lightwalletProtocolVersion is not populated. It is declared in the generated walletrpc bindings and read by clients, but not served by lightwalletd.

The field is specified in lightwallet-protocol at lightwallet-protocol/walletrpc/service.proto:118:

    string lightwalletProtocolVersion = 18; // version of
    // https://github.com/zcash/lightwallet-protocol served by this server

and the same specification makes checking it a client requirement, in the documentation of BlockRange at service.proto:35-38:

    Clients MUST verify that the version of the server they are
    connected to are capable of returning pruned and/or transparent
    data before setting `poolTypes` to a non-empty value.

Both were introduced together in lightwallet-protocol v0.4.0, which is what ties them: the version string is the means by which a client discharges that MUST. 

**The consequence of leaving the field empty is that it is indistinguishable from a pre-v0.4.0 server.**

A client that honors the MUST has no way to tell a server that serves transparent and Ironwood data inside compact blocks from one that does not, so it must fall back to shielded-only scanning, against servers that have in fact served the data since 0.5.0.

Confirmed against a public 0.5.2 deployment: GetBlockRange with poolTypes set returns vin, vout and ironwoodActions exactly as specified, while GetLightdInfo on the same server reports no protocol version at all.

The practical result is that transparent light-wallet support looks unavailable everywhere, and clients that want it have to be told out of band, by the operator, to disregard the probe.

### Implementation Note

This reports the version as a constant rather than one of the build-stamped variables above it: it describes the protocol served, not the build, and letting 'make build' overwrite it would defeat the point. It must be updated together with the lightwallet-protocol subtree, and only once the server actually serves what the named version specifies. The subtree is currently at v0.5.0.