### PR TITLE
frontend: apply the address-count cap to GetTaddressBalance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ The most recent changes are listed first.
 
 ### Fixed
 
+- `GetTaddressBalance` now rejects an address list longer than the same 10,000
+  limit that `GetTaddressBalanceStream`, `GetAddressUtxos` and
+  `GetAddressUtxosStream` already enforce. The unary method takes its whole
+  list in one protobuf message, so its only bound was gRPC's 4MB
+  `MaxRecvMsgSize` — roughly 113,000 addresses at 37 wire bytes each, an order
+  of magnitude above the intended cap. A single request could therefore ask
+  the backend for eleven times more address-index lookups than any other
+  method allows, and return only an 8-byte balance (GHSA-x4m7-3gpp-xc36).
+
 - Report `lightwalletProtocolVersion` in `GetLightdInfo`. The field was added
   to `LightdInfo` in lightwallet-protocol v0.4.0, in the same release as
   `BlockRange.poolTypes`, and is the signal clients are required to check

--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -385,6 +385,60 @@ func TestGetTaddressBalanceStream(t *testing.T) {
 	}
 }
 
+func TestGetTaddressBalanceTooManyAddresses(t *testing.T) {
+	testT = t
+	defer resetGlobals()
+	lwd, _ := testsetup()
+
+	// The unary method takes the whole list in one protobuf message, so its
+	// only bound was gRPC's 4MB MaxRecvMsgSize -- about 113,000 addresses at
+	// 37 wire bytes each, an order of magnitude above the cap the streaming
+	// and utxo methods enforce (GHSA-x4m7-3gpp-xc36).
+	//
+	// Distinct addresses, so that the counts here are unaffected by any later
+	// deduplication of the list.
+	addrs := make([]string, maxTaddrsPerRequest+1)
+	for i := range addrs {
+		addrs[i] = fmt.Sprintf("t1%033d", i)
+	}
+
+	// Exactly at the limit: accepted, and the whole list reaches zcashd.
+	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
+		if method != "getaddressbalance" {
+			testT.Fatal("unexpected method", method)
+		}
+		var req common.ZcashdRpcRequestGetaddressbalance
+		if err := json.Unmarshal(params[0], &req); err != nil {
+			testT.Fatal("could not unmarshal getaddressbalance request")
+		}
+		if len(req.Addresses) != maxTaddrsPerRequest {
+			testT.Fatal("expected the whole list to reach zcashd, got:", len(req.Addresses))
+		}
+		return json.Marshal(common.ZcashdRpcReplyGetaddressbalance{Balance: 1234})
+	}
+	balance, err := lwd.GetTaddressBalance(context.Background(),
+		&walletrpc.AddressList{Addresses: addrs[:maxTaddrsPerRequest]})
+	if err != nil {
+		t.Fatal("GetTaddressBalance failed at exactly the limit:", err)
+	}
+	if balance.ValueZat != 1234 {
+		t.Fatal("unexpected balance:", balance.ValueZat)
+	}
+
+	// One over: rejected before zcashd is contacted.
+	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
+		testT.Fatal("zcashd must not be called when the address list is over the limit")
+		return nil, nil
+	}
+	_, err = lwd.GetTaddressBalance(context.Background(), &walletrpc.AddressList{Addresses: addrs})
+	if err == nil {
+		t.Fatal("GetTaddressBalance should have failed on too many addresses")
+	}
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatal("expected ResourceExhausted on too many addresses, got:", err)
+	}
+}
+
 func TestGetAddressUtxosTooManyAddresses(t *testing.T) {
 	testT = t
 	defer resetGlobals()

--- a/frontend/service.go
+++ b/frontend/service.go
@@ -581,6 +581,11 @@ func (s *lwdStreamer) SendTransaction(ctx context.Context, rawtx *walletrpc.RawT
 }
 
 func getTaddressBalanceZcashdRpc(ctx context.Context, addressList []string) (*walletrpc.Balance, error) {
+	// GHSA-x4m7-3gpp-xc36
+	if len(addressList) > maxTaddrsPerRequest {
+		return nil, status.Errorf(codes.ResourceExhausted,
+			"getTaddressBalanceZcashdRpc: too many addresses (limit %d)", maxTaddrsPerRequest)
+	}
 	for _, addr := range addressList {
 		if err := checkTaddress(addr); err != nil {
 			return nil, err
@@ -633,9 +638,8 @@ func (s *lwdStreamer) GetTaddressBalance(ctx context.Context, addresses *walletr
 // memory growth and backend work: GetTaddressBalanceStream accumulates
 // streamed addresses until the process is OOM-killed, and GetAddressUtxos
 // forwards the whole list to zcashd and materializes the full result before
-// applying client-side limits. The unary GetTaddressBalance is already
-// implicitly bounded by gRPC's MaxRecvMsgSize; this gives the other methods an
-// equivalent bound, generous for any legitimate wallet (GHSA-x4m7-3gpp-xc36).
+// applying client-side limits. Generous for any legitimate wallet
+// (GHSA-x4m7-3gpp-xc36).
 const maxTaddrsPerRequest = 10000
 
 // GetTaddressBalanceStream returns the total balance for a list of taddrs


### PR DESCRIPTION
`maxTaddrsPerRequest` (10,000) bounds `GetTaddressBalanceStream`, `GetAddressUtxos` and `GetAddressUtxosStream`, but not the unary `GetTaddressBalance`.

The comment on the constant claimed that method was "already implicitly bounded by gRPC's `MaxRecvMsgSize`", giving "an equivalent bound". It is bounded — but not equivalently. The unary request carries its whole list in a single protobuf message, so grpc-go's 4MB default applies to the message as a whole:

```
4,194,304 bytes / 37 bytes per address ≈ 113,000 addresses
```

(37 = 1 tag byte + 1 length byte + 35 address characters.) That is eleven times the cap every sibling method enforces.

The streaming method genuinely does need its own explicit cap, because each `Address` arrives as its own small message and `MaxRecvMsgSize` never applies to the total — that part of the original reasoning was right. It just doesn't follow that the unary bound is equivalent.

## Impact

One method forwards an order of magnitude more addresses to the backend than any other allows, and returns a single `int64`. Small reply, large backend work — up to ~113,000 address-index lookups per request.

The 4MB request is real cost to the attacker, so this is weaker than an unbounded vector, and it is not the worst amplification path in this area. But there is no reason for one of four methods taking the same input to have a bound an order of magnitude looser than the others, discoverable only by dividing 4MB by 37.

The deduplication in #586 does not help here: distinct addresses cost the attacker nothing to generate, and they need not be funded (they do need valid base58 checksums, since `checkTaddress` only checks the character set — but those are trivially generated offline).

## Change

The cap goes in `getTaddressBalanceZcashdRpc`, the choke point both the unary and streaming paths call, so it covers both. The stream keeps its own check, which rejects addresses as they arrive rather than after buffering them.

The stale claim is dropped from the constant's comment.

## Testing

`TestGetTaddressBalanceTooManyAddresses` asserts that `maxTaddrsPerRequest + 1` addresses yield `ResourceExhausted` and that the backend is never contacted. Mutation-tested: removing the cap fails the test.

Note this PR touches `getTaddressBalanceZcashdRpc`, as does #586. Whichever merges second may need a trivial conflict resolution — the two changes are independent (one bounds the list, the other deduplicates it).
