### PR TITLE
chore: match delve debug binaries with a suffix in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,6 @@ coverage.out
 test-log
 lwd-api.html
 *.orig
-__debug_bin
+__debug_bin*
 .vscode
 */unittestcache/


### PR DESCRIPTION
`.gitignore` has `__debug_bin`, which vscode-go used to write as exactly that name. It now appends a random suffix — `__debug_bin2646226387`, for instance — so the pattern stopped matching and the binary shows up as untracked in whichever package you were debugging.

At roughly 23MB it is easy to sweep into a commit by accident with a broad `git add`.

One character: `__debug_bin` → `__debug_bin*`.

(Just my guess, but the likely reason for the change to add a random suffix is so that you can have multiple debug sessions in progress at the same time, potentially with different binaries; this way there's no conflict, or at least conflict is extremely unlikely.)