### PR TITLE
frontend: reject an unknown shielded protocol with InvalidArgument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ The most recent changes are listed first.
 
 ### Fixed
 
+- `GetSubtreeRoots` now rejects an unrecognized `ShieldedProtocol` with
+  `InvalidArgument` instead of `Unknown`. It was the one production handler
+  returning a bare Go error, which gRPC surfaces as `codes.Unknown` -- the code
+  a client reads as "the server had a problem" and backs off and retries on,
+  for a request that cannot succeed until the caller changes it. The darkside
+  `Reset` handler's `ChainName` check returned a bare error the same way, four
+  lines below its `BranchID` check, which already used `InvalidArgument`.
+
 - `GetTaddressBalance` now rejects an address list longer than the same 10,000
   limit that `GetTaddressBalanceStream`, `GetAddressUtxos` and
   `GetAddressUtxosStream` already enforce. The unary method takes its whole

--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -1437,3 +1437,71 @@ func TestGetMempoolTxAbortsRefreshOnClientCancel(t *testing.T) {
 		t.Fatalf("a partial cache was published: %d entries", len(*mempoolMap))
 	}
 }
+
+type testgetsubtreeroots struct {
+	walletrpc.CompactTxStreamer_GetSubtreeRootsServer
+}
+
+func (tg *testgetsubtreeroots) Context() context.Context {
+	return context.Background()
+}
+
+func (tg *testgetsubtreeroots) Send(sr *walletrpc.SubtreeRoot) error {
+	return nil
+}
+
+// An unrecognized ShieldedProtocol is the caller's mistake, so it must arrive as
+// InvalidArgument. Returning a bare error made it codes.Unknown -- "something went
+// wrong on the server" -- which is the code wallets back off and retry on, for a
+// request that can never succeed.
+func TestGetSubtreeRootsUnknownProtocolIsInvalidArgument(t *testing.T) {
+	testT = t
+	defer resetGlobals()
+	lwd, _ := testsetup()
+
+	common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
+		testT.Fatal("the backend must not be called for an unrecognized shielded protocol")
+		return nil, nil
+	}
+	err := lwd.GetSubtreeRoots(&walletrpc.GetSubtreeRootsArg{
+		ShieldedProtocol: walletrpc.ShieldedProtocol(9999),
+	}, &testgetsubtreeroots{})
+	if err == nil {
+		t.Fatal("GetSubtreeRoots should have failed on an unrecognized shielded protocol")
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatal("expected InvalidArgument for an unrecognized shielded protocol, got:",
+			status.Code(err), err)
+	}
+
+	// The recognized protocols still reach the backend, named as the RPC expects.
+	for _, protocol := range []walletrpc.ShieldedProtocol{
+		walletrpc.ShieldedProtocol_sapling,
+		walletrpc.ShieldedProtocol_orchard,
+		walletrpc.ShieldedProtocol_ironwood,
+	} {
+		called := false
+		common.RawRequest = func(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
+			called = true
+			if method != "z_getsubtreesbyindex" {
+				testT.Fatal("unexpected method", method)
+			}
+			var name string
+			if err := json.Unmarshal(params[0], &name); err != nil {
+				testT.Fatal("could not unmarshal the protocol parameter")
+			}
+			if name != protocol.String() {
+				testT.Fatal("expected protocol", protocol.String(), "got", name)
+			}
+			return json.Marshal(common.ZcashdRpcReplyGetsubtreebyindex{})
+		}
+		if err := lwd.GetSubtreeRoots(&walletrpc.GetSubtreeRootsArg{
+			ShieldedProtocol: protocol,
+		}, &testgetsubtreeroots{}); err != nil {
+			t.Fatal("GetSubtreeRoots failed for", protocol.String(), err)
+		}
+		if !called {
+			t.Fatal("the backend was not called for", protocol.String())
+		}
+	}
+}

--- a/frontend/service.go
+++ b/frontend/service.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"io"
 	"os"
 	"regexp"
@@ -1009,7 +1008,12 @@ func (s *lwdStreamer) GetSubtreeRoots(arg *walletrpc.GetSubtreeRootsArg, resp wa
 	case walletrpc.ShieldedProtocol_ironwood:
 		break
 	default:
-		return errors.New("unrecognized shielded protocol")
+		// A status error, like every other rejection of client input here: a bare
+		// error reaches the client as codes.Unknown, which is the code for "something
+		// went wrong on the server". Wallets retry that. An unrecognized protocol is
+		// the caller's to fix, and InvalidArgument is what says so.
+		return status.Errorf(codes.InvalidArgument,
+			"GetSubtreeRoots: unrecognized shielded protocol: %s", arg.ShieldedProtocol)
 	}
 	protocol, err := json.Marshal(arg.ShieldedProtocol.String())
 	if err != nil {
@@ -1111,7 +1115,8 @@ func (s *DarksideStreamer) Reset(ctx context.Context, ms *walletrpc.DarksideMeta
 
 	match, err = regexp.Match("\\A[a-zA-Z0-9]+\\z", []byte(ms.ChainName))
 	if err != nil || !match {
-		return nil, errors.New("invalid chain name")
+		return nil, status.Errorf(codes.InvalidArgument,
+			"Reset: invalid ChainName (must be alphanumeric): %s", ms.ChainName)
 	}
 	err = common.DarksideReset(
 		int(ms.SaplingActivation),


### PR DESCRIPTION
## The bug

`GetSubtreeRoots` validates `arg.ShieldedProtocol` and then returns a bare Go error:

```go
default:
    return errors.New("unrecognized shielded protocol")
```

gRPC has no code to read off a bare error, so it reaches the client as `codes.Unknown` — *"the server had a problem"*. That is a code clients back off and retry on, and this request cannot succeed until the caller changes it. The right answer is `InvalidArgument`: the caller's to fix, don't retry.

Every other rejection of client input in this file returns a status error — including the `json.Marshal` check four lines further down in the same function. These were the only two bare ones, out of 81 error returns in `frontend/service.go`.

Measured against the handler:

```
status.Code(err) == codes.Unknown          // before
status.Code(err) == codes.InvalidArgument  // after
```

The darkside `Reset` handler's `ChainName` check had the same shape, four lines below its `BranchID` check, which already used `InvalidArgument`. Fixed alongside, since it is the same one-line pattern in the same file.

## Tests

`GetSubtreeRoots` had no test at all. The new one pins the code for an unrecognized protocol and asserts the backend is never contacted, then checks that all three recognized protocols still reach `z_getsubtreesbyindex` under the names it expects — so the switch cannot be tightened into rejecting a valid protocol without the test noticing.

Reverting only `frontend/service.go` and keeping the test fails as:

```
frontend_test.go:1473: expected InvalidArgument for an unrecognized shielded protocol,
    got: Unknown unrecognized shielded protocol
```

`go test ./...` is green across all seven packages, `go vet ./frontend/` is clean, and `gofmt -l frontend/` is empty. (`go vet ./testclient/` reports three unexported-json-tag warnings on master already; untouched here.)

Changelog entry added under Unreleased → Fixed.

## Scope note

Removing the last two uses of `errors.New` in this file left the `errors` import unused, so it goes too — that is the only reason the import block is in the diff.

---
🤖 Written with [Claude Code](https://claude.com/claude-code). Every result above is from a local run.
