### PR TITLE
frontend, common: comment cleanups

### DIFF
--- a/common/darkside.go
+++ b/common/darkside.go
@@ -182,7 +182,7 @@ func DarksideReset(sa int, bi, cn string, sst, sot, sit uint32) error {
 	return nil
 }
 
-// DarksideAddBlock adds a single block to the active blocks list.
+// addBlockActive adds a single block to the active blocks list.
 func addBlockActive(blockBytes []byte) error {
 	block := parser.NewBlock()
 	rest, err := block.ParseFromSlice(blockBytes)

--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -1450,10 +1450,7 @@ func (tg *testgetsubtreeroots) Send(sr *walletrpc.SubtreeRoot) error {
 	return nil
 }
 
-// An unrecognized ShieldedProtocol is the caller's mistake, so it must arrive as
-// InvalidArgument. Returning a bare error made it codes.Unknown -- "something went
-// wrong on the server" -- which is the code wallets back off and retry on, for a
-// request that can never succeed.
+// An unrecognized ShieldedProtocol must arrive as InvalidArgument, not Unknown.
 func TestGetSubtreeRootsUnknownProtocolIsInvalidArgument(t *testing.T) {
 	testT = t
 	defer resetGlobals()

--- a/frontend/service.go
+++ b/frontend/service.go
@@ -1008,10 +1008,7 @@ func (s *lwdStreamer) GetSubtreeRoots(arg *walletrpc.GetSubtreeRootsArg, resp wa
 	case walletrpc.ShieldedProtocol_ironwood:
 		break
 	default:
-		// A status error, like every other rejection of client input here: a bare
-		// error reaches the client as codes.Unknown, which is the code for "something
-		// went wrong on the server". Wallets retry that. An unrecognized protocol is
-		// the caller's to fix, and InvalidArgument is what says so.
+		// A bare error would reach the client as codes.Unknown, which wallets retry.
 		return status.Errorf(codes.InvalidArgument,
 			"GetSubtreeRoots: unrecognized shielded protocol: %s", arg.ShieldedProtocol)
 	}

--- a/frontend/service.go
+++ b/frontend/service.go
@@ -97,9 +97,8 @@ func (s *lwdStreamer) GetLatestBlock(ctx context.Context, placeholder *walletrpc
 // address-index scan (GHSA-x4m7-3gpp-xc36, finding 2).
 const maxTaddrTxBlockSpan = 10_000_000
 
-// GetTaddressTxids is a streaming RPC that returns transactions that have
-// the given transparent address (taddr) as either an input or output.
-// NB, this method is misnamed, it does not return txids.
+// GetTaddressTransactions is a streaming RPC that returns transactions that
+// have the given transparent address (taddr) as either an input or output.
 func (s *lwdStreamer) GetTaddressTransactions(addressBlockFilter *walletrpc.TransparentAddressBlockFilter, resp walletrpc.CompactTxStreamer_GetTaddressTransactionsServer) error {
 	common.Log.Debugf("gRPC GetTaddressTransactions(%+v)\n", addressBlockFilter)
 	if err := checkTaddress(addressBlockFilter.Address); err != nil {


### PR DESCRIPTION
Two comment-only cleanups for the release. No behavior change; `gofmt` clean, full test suite passes.

**`frontend: shorten two comments to one line each`** — trims the two multi-line comments added by #595 down to one line each. The reasoning they carried, that `codes.Unknown` is the wrong code for a request the caller must change and that wallets back off and retry on it, is already stated in full in the CHANGELOG entry #595 added, so nothing is lost.

**`frontend, common: name the right functions in two doc comments`** — both comments named a function other than the one they document, so `go doc` and every editor that reads doc comments attributed them to nothing. `GetTaddressTransactions` was still documented as `GetTaddressTxids`, the name it carried before 8c4c83a split the deprecated RPC into its own wrapper; its "NB, this method is misnamed" note goes away with the rename, since it described `GetTaddressTxids`, which is still present and still carries that explanation in full on the wrapper 90 lines below. `addBlockActive` was documented as `DarksideAddBlock`, a name that no longer exists anywhere in the tree.

Reported in #524 and #526, both of which conflicted with master and are closed in favor of this.
