### PR TITLE
CHANGELOG: file the pending entries under 0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The most recent changes are listed first.
 
-## [Unreleased]
+## [0.5.4] - 2026-08-27
 
 ### Changed
 


### PR DESCRIPTION
Files the pending CHANGELOG entries under 0.5.4 ahead of the release. No code change.

Contents of 0.5.4, all already merged:

- `GetAddressUtxos`/`GetAddressUtxosStream` pass `startHeight` and `maxEntries` through to the backend RPC (#586 follow-up)
- `GetSubtreeRoots` rejects an unrecognized `ShieldedProtocol` with `InvalidArgument` instead of `Unknown` (#595)
- `GetTaddressBalance` enforces the 10,000-address cap the other three methods already had (GHSA-x4m7-3gpp-xc36)
- `GetLightdInfo` reports `lightwalletProtocolVersion`, which had always been the empty string
- `GetTaddressBalance`/`GetTaddressBalanceStream` deduplicate the address list, so a repeated address no longer inflates the reported balance
- `GetAddressUtxos`/`GetAddressUtxosStream` deduplicate the address list (GHSA-x4m7-3gpp-xc36)
